### PR TITLE
add descriptive error types

### DIFF
--- a/crates/genie-cpx/src/lib.rs
+++ b/crates/genie-cpx/src/lib.rs
@@ -45,7 +45,7 @@ pub struct ScenarioMeta {
     pub filename: String,
 }
 
-pub use read::Campaign;
+pub use read::{Campaign, ReadCampaignError};
 pub use write::CampaignWriter;
 
 impl<R> Campaign<R>
@@ -57,7 +57,9 @@ where
         let mut writer = CampaignWriter::new(self.name(), output);
 
         for i in 0..self.len() {
-            let bytes = self.by_index_raw(i)?;
+            let bytes = self
+                .by_index_raw(i)
+                .map_err(|_| Error::new(ErrorKind::Other, "missing data for scenario"))?;
             match (self.get_name(i), self.get_filename(i)) {
                 (Some(name), Some(filename)) => {
                     writer.add_raw(name, filename, bytes);

--- a/crates/genie-cpx/src/lib.rs
+++ b/crates/genie-cpx/src/lib.rs
@@ -2,10 +2,13 @@
 //!
 //! genie-cpx can read and write campaign files using the Campaign and CampaignWriter structs,
 //! respectively.
-use std::io::{Error, ErrorKind, Read, Result, Seek, Write};
+use std::io::{Read, Seek, Write};
 
 mod read;
 mod write;
+
+pub use read::{Campaign, ReadCampaignError};
+pub use write::{CampaignWriter, WriteCampaignError};
 
 /// Version identifier for the campaign file format.
 ///
@@ -45,26 +48,23 @@ pub struct ScenarioMeta {
     pub filename: String,
 }
 
-pub use read::{Campaign, ReadCampaignError};
-pub use write::CampaignWriter;
-
 impl<R> Campaign<R>
 where
     R: Read + Seek,
 {
     /// Write the scenario file to an output stream.
-    pub fn write_to<W: Write>(&mut self, output: &mut W) -> Result<()> {
+    pub fn write_to<W: Write>(&mut self, output: &mut W) -> Result<(), WriteCampaignError> {
         let mut writer = CampaignWriter::new(self.name(), output);
 
         for i in 0..self.len() {
             let bytes = self
                 .by_index_raw(i)
-                .map_err(|_| Error::new(ErrorKind::Other, "missing data for scenario"))?;
+                .map_err(|_| WriteCampaignError::NotFoundError(i))?;
             match (self.get_name(i), self.get_filename(i)) {
                 (Some(name), Some(filename)) => {
                     writer.add_raw(name, filename, bytes);
                 }
-                _ => return Err(Error::new(ErrorKind::Other, "missing data for scenario")),
+                _ => return Err(WriteCampaignError::NotFoundError(i)),
             }
         }
 

--- a/crates/genie-cpx/src/read.rs
+++ b/crates/genie-cpx/src/read.rs
@@ -1,7 +1,44 @@
 use crate::{CPXVersion, CampaignHeader, ScenarioMeta};
 use byteorder::{ReadBytesExt, LE};
-use genie_scx::Scenario;
-use std::io::{Error, ErrorKind, Read, Result, Seek, SeekFrom};
+use genie_scx::{self as scx, Scenario};
+use std::io::{self, Cursor, Read, Seek, SeekFrom};
+
+#[derive(Debug)]
+pub enum ReadCampaignError {
+    DecodeStringError,
+    IoError(io::Error),
+    MissingNameError,
+    NotFoundError,
+    ParseSCXError(scx::Error),
+}
+
+impl From<io::Error> for ReadCampaignError {
+    fn from(err: io::Error) -> ReadCampaignError {
+        ReadCampaignError::IoError(err)
+    }
+}
+
+impl From<scx::Error> for ReadCampaignError {
+    fn from(err: scx::Error) -> ReadCampaignError {
+        ReadCampaignError::ParseSCXError(err)
+    }
+}
+
+impl std::fmt::Display for ReadCampaignError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            ReadCampaignError::DecodeStringError => write!(f, "invalid string"),
+            ReadCampaignError::IoError(err) => write!(f, "{}", err),
+            ReadCampaignError::MissingNameError => {
+                write!(f, "campaign or scenario must have a name")
+            }
+            ReadCampaignError::NotFoundError => write!(f, "scenario not found in campaign"),
+            ReadCampaignError::ParseSCXError(err) => write!(f, "{}", err),
+        }
+    }
+}
+
+type Result<T> = std::result::Result<T, ReadCampaignError>;
 
 pub fn read_fixed_str<R: Read>(input: &mut R, len: usize) -> Result<Option<String>> {
     let mut bytes = vec![0; len];
@@ -15,14 +52,14 @@ pub fn read_fixed_str<R: Read>(input: &mut R, len: usize) -> Result<Option<Strin
     } else {
         String::from_utf8(bytes)
             .map(Some)
-            .map_err(|_| Error::new(ErrorKind::Other, "invalid string"))
+            .map_err(|_| ReadCampaignError::DecodeStringError)
     }
 }
 
 fn read_campaign_header<R: Read>(input: &mut R) -> Result<CampaignHeader> {
     let mut version = [0; 4];
     input.read_exact(&mut version)?;
-    let name = read_fixed_str(input, 256)?.expect("must have a name");
+    let name = read_fixed_str(input, 256)?.ok_or(ReadCampaignError::MissingNameError)?;
     let num_scenarios = input.read_i32::<LE>()? as usize;
 
     Ok(CampaignHeader {
@@ -35,8 +72,8 @@ fn read_campaign_header<R: Read>(input: &mut R) -> Result<CampaignHeader> {
 fn read_scenario_meta<R: Read>(input: &mut R) -> Result<ScenarioMeta> {
     let size = input.read_i32::<LE>()? as usize;
     let offset = input.read_i32::<LE>()? as usize;
-    let name = read_fixed_str(input, 255)?.expect("must have a name");
-    let filename = read_fixed_str(input, 255)?.expect("must have a name");
+    let name = read_fixed_str(input, 255)?.ok_or(ReadCampaignError::MissingNameError)?;
+    let filename = read_fixed_str(input, 255)?.ok_or(ReadCampaignError::MissingNameError)?;
     let mut padding = [0; 2];
     input.read_exact(&mut padding)?;
 
@@ -126,26 +163,21 @@ where
     /// Get a scenario by its file name.
     pub fn by_name(&mut self, filename: &str) -> Result<Scenario> {
         self.by_name_raw(filename)
-            .map(std::io::Cursor::new)
-            .and_then(|mut buf| Scenario::from(&mut buf))
+            .map(Cursor::new)
+            .and_then(|mut buf| Scenario::from(&mut buf).map_err(ReadCampaignError::ParseSCXError))
     }
 
     /// Get a scenario by its campaign index.
     pub fn by_index(&mut self, index: usize) -> Result<Scenario> {
         self.by_index_raw(index)
-            .map(std::io::Cursor::new)
-            .and_then(|mut buf| Scenario::from(&mut buf))
+            .map(Cursor::new)
+            .and_then(|mut buf| Scenario::from(&mut buf).map_err(ReadCampaignError::ParseSCXError))
     }
 
     /// Get a scenario file buffer by its file name.
     pub fn by_name_raw(&mut self, filename: &str) -> Result<Vec<u8>> {
         self.get_id(filename)
-            .ok_or_else(|| {
-                std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    "scenario not found in campaign",
-                )
-            })
+            .ok_or(ReadCampaignError::NotFoundError)
             .and_then(|index| self.by_index_raw(index))
     }
 
@@ -153,12 +185,7 @@ where
     pub fn by_index_raw(&mut self, index: usize) -> Result<Vec<u8>> {
         let entry = match self.entries.get(index) {
             Some(entry) => entry,
-            None => {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    "scenario not found in campaign",
-                ))
-            }
+            None => return Err(ReadCampaignError::NotFoundError),
         };
 
         let mut result = vec![];

--- a/crates/genie-cpx/src/write.rs
+++ b/crates/genie-cpx/src/write.rs
@@ -1,6 +1,6 @@
 use crate::{CampaignHeader, ScenarioMeta};
 use byteorder::{WriteBytesExt, LE};
-use genie_scx::Scenario;
+use genie_scx::{Result as SCXResult, Scenario};
 use std::io::{Result, Write};
 
 fn write_campaign_header<W: Write>(header: &CampaignHeader, output: &mut W) -> Result<()> {
@@ -82,7 +82,7 @@ impl<W: Write> CampaignWriter<W> {
         });
     }
 
-    pub fn add(&mut self, name: &str, scx: &Scenario) -> Result<()> {
+    pub fn add(&mut self, name: &str, scx: &Scenario) -> SCXResult<()> {
         let mut bytes = vec![];
         scx.write_to(&mut bytes)?;
         self.scenarios.push(CampaignEntry {

--- a/crates/genie-cpx/src/write.rs
+++ b/crates/genie-cpx/src/write.rs
@@ -1,9 +1,36 @@
 use crate::{CampaignHeader, ScenarioMeta};
 use byteorder::{WriteBytesExt, LE};
 use genie_scx::{Result as SCXResult, Scenario};
-use std::io::{Result, Write};
+use std::io::{self, Write};
 
-fn write_campaign_header<W: Write>(header: &CampaignHeader, output: &mut W) -> Result<()> {
+#[derive(Debug)]
+pub enum WriteCampaignError {
+    // TODO String could not be encoded.
+    // EncodeStringError,
+    IoError(io::Error),
+    NotFoundError(usize),
+}
+
+impl From<io::Error> for WriteCampaignError {
+    fn from(err: io::Error) -> WriteCampaignError {
+        WriteCampaignError::IoError(err)
+    }
+}
+
+impl std::fmt::Display for WriteCampaignError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            WriteCampaignError::IoError(err) => write!(f, "{}", err),
+            WriteCampaignError::NotFoundError(n) => {
+                write!(f, "missing scenario data for index {}", n)
+            }
+        }
+    }
+}
+
+impl std::error::Error for WriteCampaignError {}
+
+fn write_campaign_header<W: Write>(header: &CampaignHeader, output: &mut W) -> io::Result<()> {
     assert!(header.num_scenarios < std::i32::MAX as usize);
 
     output.write_all(&header.version)?;
@@ -15,7 +42,7 @@ fn write_campaign_header<W: Write>(header: &CampaignHeader, output: &mut W) -> R
     Ok(())
 }
 
-fn write_scenario_meta<W: Write>(meta: &ScenarioMeta, output: &mut W) -> Result<()> {
+fn write_scenario_meta<W: Write>(meta: &ScenarioMeta, output: &mut W) -> io::Result<()> {
     assert!(meta.size < std::i32::MAX as usize);
     assert!(meta.offset < std::i32::MAX as usize);
 
@@ -97,12 +124,12 @@ impl<W: Write> CampaignWriter<W> {
         self.writer
     }
 
-    fn write_header(&mut self) -> Result<()> {
+    fn write_header(&mut self) -> io::Result<()> {
         self.header.num_scenarios = self.scenarios.len();
         write_campaign_header(&self.header, &mut self.writer)
     }
 
-    fn write_metas(&mut self) -> Result<()> {
+    fn write_metas(&mut self) -> io::Result<()> {
         let mut offset = 256 + 8 + self.scenarios.len() * (255 + 255 + 8);
         for scen in &self.scenarios {
             let meta = ScenarioMeta {
@@ -117,14 +144,14 @@ impl<W: Write> CampaignWriter<W> {
         Ok(())
     }
 
-    fn write_scenarios(&mut self) -> Result<()> {
+    fn write_scenarios(&mut self) -> io::Result<()> {
         for scen in &self.scenarios {
             self.writer.write_all(scen.bytes())?;
         }
         Ok(())
     }
 
-    pub fn flush(mut self) -> Result<W> {
+    pub fn flush(mut self) -> io::Result<W> {
         self.write_header()?;
         self.write_metas()?;
         self.write_scenarios()?;

--- a/crates/genie-drs/src/lib.rs
+++ b/crates/genie-drs/src/lib.rs
@@ -5,18 +5,21 @@
 //! ## Example
 //!
 //! ```rust
+//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
 //! use std::fs::File;
 //! use genie_drs::DRSReader;
 //!
-//! let mut file = File::open("test.drs").unwrap();
-//! let drs = DRSReader::new(&mut file).unwrap();
+//! let mut file = File::open("test.drs")?;
+//! let drs = DRSReader::new(&mut file)?;
 //!
 //! for table in drs.tables() {
 //!     for resource in table.resources() {
-//!         let content = drs.read_resource(&mut file, table.resource_type, resource.id).unwrap();
-//!         println!("{}: {:?}", resource.id, std::str::from_utf8(&content).unwrap());
+//!         let content = drs.read_resource(&mut file, table.resource_type, resource.id)?;
+//!         println!("{}: {:?}", resource.id, std::str::from_utf8(&content)?);
 //!     }
 //! }
+//! # Ok(())
+//! # }
 //! ```
 
 use byteorder::{ReadBytesExt, LE};

--- a/crates/genie-scx/src/ai.rs
+++ b/crates/genie-scx/src/ai.rs
@@ -1,8 +1,8 @@
-use crate::util::*;
+use crate::{util::*, Result};
 use byteorder::{ReadBytesExt, WriteBytesExt, LE};
 use num_derive::FromPrimitive;
 use num_traits::FromPrimitive;
-use std::io::{Error, ErrorKind, Read, Result, Write};
+use std::io::{Read, Write};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, FromPrimitive)]
 pub enum AIErrorCode {
@@ -43,7 +43,7 @@ pub struct AIErrorInfo {
     error_code: AIErrorCode,
 }
 
-fn parse_bytes(bytes: &[u8]) -> Result<String> {
+fn parse_bytes(bytes: &[u8]) -> std::result::Result<String, ReadStringError> {
     let mut bytes = bytes.to_vec();
     if let Some(end) = bytes.iter().position(|&byte| byte == 0) {
         bytes.truncate(end);
@@ -51,7 +51,7 @@ fn parse_bytes(bytes: &[u8]) -> Result<String> {
     if bytes.is_empty() {
         Ok("<empty>".to_string())
     } else {
-        String::from_utf8(bytes).map_err(|_| Error::new(ErrorKind::Other, "invalid string"))
+        String::from_utf8(bytes).map_err(|_| ReadStringError::DecodeStringError(DecodeStringError))
     }
 }
 

--- a/crates/genie-scx/src/bitmap.rs
+++ b/crates/genie-scx/src/bitmap.rs
@@ -1,7 +1,8 @@
 //! Handles bitmap files embedded in the scenario file.
 
+use crate::Result;
 use byteorder::{ReadBytesExt, WriteBytesExt, LE};
-use std::io::{Read, Result, Write};
+use std::io::{Read, Write};
 
 /// A colour in the bitmap palette.
 ///

--- a/crates/genie-scx/src/convert/hd_to_wk.rs
+++ b/crates/genie-scx/src/convert/hd_to_wk.rs
@@ -2,6 +2,9 @@ use super::ConvertError;
 use crate::{Scenario, ScenarioObject, Tile, Trigger};
 use std::collections::HashMap;
 
+/// Convert an HD Edition scenario to a WololoKingdoms-compatible one.
+///
+/// Maps HD unit IDs and terrain IDs to their WK equivalents.
 pub struct HDToWK {
     object_ids_map: HashMap<i32, i32>,
     terrain_ids_map: HashMap<i8, i8>,

--- a/crates/genie-scx/src/convert/mod.rs
+++ b/crates/genie-scx/src/convert/mod.rs
@@ -1,3 +1,6 @@
+//! Automated scenario conversions.
+//!
+//! This module implements conversions between different scenario formats and game versions.
 mod aoc_to_wk;
 mod hd_to_wk;
 
@@ -6,8 +9,10 @@ use crate::Scenario;
 pub use aoc_to_wk::AoCToWK;
 pub use hd_to_wk::HDToWK;
 
+/// Error indicating scenario conversion failure.
 #[derive(Debug)]
 pub enum ConvertError {
+    /// The input scenario version is not supported by the converter.
     InvalidVersion,
 }
 
@@ -21,6 +26,19 @@ impl std::fmt::Display for ConvertError {
 
 impl std::error::Error for ConvertError {}
 
+/// Convert an AoC or HD Edition scenario file to a WololoKingdoms one.
+///
+/// It will auto-detect the version of the file, and output a WK compatible scenario.
+/// AoC scenarios will have their unit and terrain IDs switched around so they have the correct
+/// look in WK.
+/// HD Edition scenarios will have all the new unit and terrain IDs mapped to WK IDs.
+///
+/// ## Usage
+///
+/// ```rust,ignore
+/// use genie_scx::convert::AutoToWK;
+/// AutoToWK::default().convert(&mut scenario)?
+/// ```
 pub struct AutoToWK {}
 
 impl Default for AutoToWK {

--- a/crates/genie-scx/src/format.rs
+++ b/crates/genie-scx/src/format.rs
@@ -2,20 +2,14 @@
 
 #![allow(clippy::cyclomatic_complexity)]
 
-use crate::ai::AIInfo;
-use crate::bitmap::Bitmap;
-use crate::header::SCXHeader;
-use crate::map::Map;
-use crate::player::*;
-use crate::triggers::TriggerSystem;
-use crate::types::*;
-use crate::util::*;
-use crate::victory::*;
-use crate::VersionBundle;
+use crate::{
+    ai::AIInfo, bitmap::Bitmap, header::SCXHeader, map::Map, player::*, triggers::TriggerSystem,
+    types::*, util::*, victory::*, Error, Result, VersionBundle,
+};
 use byteorder::{ReadBytesExt, WriteBytesExt, LE};
 use flate2::{read::DeflateDecoder, write::DeflateEncoder, Compression};
 use std::cmp::Ordering;
-use std::io::{Error, ErrorKind, Read, Result, Write};
+use std::io::{Read, Write};
 
 /// Compare floats with some error.
 macro_rules! cmp_float {
@@ -206,8 +200,7 @@ impl RGEScen {
         assert!([-1.0, 0.0].contains(&input.read_f32::<LE>()?));
 
         let name_length = input.read_i16::<LE>()? as usize;
-        let name = read_str(input, name_length)?
-            .ok_or_else(|| Error::new(ErrorKind::Other, "must have a file name"))?;
+        let name = read_str(input, name_length)?.ok_or(Error::MissingFileNameError)?;
 
         let (
             description_string_table,
@@ -847,8 +840,10 @@ impl TribeScen {
         if version >= 1.18 {
             let most = *self.num_disabled_buildings.iter().max().unwrap_or(&0);
             if most > max_disabled_buildings {
-                return Err(Error::new(ErrorKind::Other,
-                      format!("too many disabled buildings: got {}, but requested version supports up to {}", most, max_disabled_buildings)));
+                return Err(Error::TooManyDisabledBuildingsError(
+                    most,
+                    max_disabled_buildings,
+                ));
             }
 
             for num in &self.num_disabled_techs {
@@ -880,25 +875,13 @@ impl TribeScen {
         } else if version > 1.03 {
             let most = *self.num_disabled_techs.iter().max().unwrap_or(&0);
             if most > 20 {
-                return Err(Error::new(
-                    ErrorKind::Other,
-                    format!(
-                        "too many disabled techs: got {}, but requested version supports up to 20",
-                        most
-                    ),
-                ));
+                return Err(Error::TooManyDisabledTechsError(most));
             }
             if self.num_disabled_units.iter().any(|&n| n > 0) {
-                return Err(Error::new(
-                    ErrorKind::Other,
-                    "requested version does not support disabling units".to_string(),
-                ));
+                return Err(Error::CannotDisableUnitsError);
             }
             if self.num_disabled_buildings.iter().any(|&n| n > 0) {
-                return Err(Error::new(
-                    ErrorKind::Other,
-                    "requested version does not support disabling buildings".to_string(),
-                ));
+                return Err(Error::CannotDisableBuildingsError);
             }
 
             // Old scenarios only allowed disabling up to 20 techs per player.
@@ -910,22 +893,13 @@ impl TribeScen {
         } else {
             // <= 1.03 did not support disabling anything
             if self.num_disabled_techs.iter().any(|&n| n > 0) {
-                return Err(Error::new(
-                    ErrorKind::Other,
-                    "requested version does not support disabling techs".to_string(),
-                ));
+                return Err(Error::CannotDisableTechsError);
             }
             if self.num_disabled_units.iter().any(|&n| n > 0) {
-                return Err(Error::new(
-                    ErrorKind::Other,
-                    "requested version does not support disabling units".to_string(),
-                ));
+                return Err(Error::CannotDisableUnitsError);
             }
             if self.num_disabled_buildings.iter().any(|&n| n > 0) {
-                return Err(Error::new(
-                    ErrorKind::Other,
-                    "requested version does not support disabling buildings".to_string(),
-                ));
+                return Err(Error::CannotDisableBuildingsError);
             }
         }
 
@@ -1092,10 +1066,7 @@ impl SCXFormat {
             b"1.20" | b"1.21" => Self::load_121(format_version, 1.14, input),
             // Definitive Edition
             b"3.13" => Self::load_121(format_version, 1.14, input),
-            _ => Err(Error::new(
-                ErrorKind::Other,
-                format!("Unsupported format version {:?}", format_version),
-            )),
+            _ => Err(Error::UnsupportedFormatVersionError(format_version)),
         }
     }
 

--- a/crates/genie-scx/src/header.rs
+++ b/crates/genie-scx/src/header.rs
@@ -1,7 +1,8 @@
 use crate::types::{DLCPackage, DataSet, SCXVersion};
 use crate::util::*;
+use crate::Result;
 use byteorder::{ReadBytesExt, WriteBytesExt, LE};
-use std::io::{Read, Result, Write};
+use std::io::{Read, Write};
 
 #[derive(Debug)]
 pub struct DLCOptions {

--- a/crates/genie-scx/src/lib.rs
+++ b/crates/genie-scx/src/lib.rs
@@ -15,13 +15,134 @@ mod util;
 mod victory;
 
 use format::SCXFormat;
-use std::io::{Read, Result, Write};
+use std::io::{self, Read, Write};
 
 pub use format::ScenarioObject;
 pub use header::{DLCOptions, SCXHeader};
 pub use map::{Map, Tile};
 pub use triggers::{Trigger, TriggerCondition, TriggerEffect, TriggerSystem};
 pub use types::*;
+pub use util::{DecodeStringError, EncodeStringError};
+
+/// Error type for SCX methods, containing all types of errors that may occur while reading or
+/// writing scenario files.
+#[derive(Debug)]
+pub enum Error {
+    /// The scenario that's attempted to be read does not contain a file name.
+    MissingFileNameError,
+    /// Attempted to read a scenario with an unsupported format version identifier.
+    UnsupportedFormatVersionError(SCXVersion),
+    /// Attempted to write a scenario with disabled technologies, to a version that doesn't support
+    /// this many disabled technologies.
+    TooManyDisabledTechsError(i32),
+    /// Attempted to write a scenario with disabled technologies, to a version that doesn't support
+    /// disabling technologies.
+    CannotDisableTechsError,
+    /// Attempted to write a scenario with disabled units, to a version that doesn't support
+    /// disabling units.
+    CannotDisableUnitsError,
+    /// Attempted to write a scenario with disabled buildings, to a version that doesn't support
+    /// this many disabled buildings.
+    TooManyDisabledBuildingsError(i32, i32),
+    /// Attempted to write a scenario with disabled buildings, to a version that doesn't support
+    /// disabling buildings.
+    CannotDisableBuildingsError,
+    /// Failed to decode a string from the scenario file, probably because of a wrong encoding.
+    DecodeStringError(DecodeStringError),
+    /// Failed to encode a string into the scenario file, probably because of a wrong encoding.
+    EncodeStringError(EncodeStringError),
+    /// The given ID is not a known diplomatic stance.
+    ParseDiplomaticStanceError(ParseDiplomaticStanceError),
+    /// The given ID is not a known data set.
+    ParseDataSetError(ParseDataSetError),
+    /// The given ID is not a known HD Edition DLC.
+    ParseDLCPackageError(ParseDLCPackageError),
+    /// The given ID is not a known starting age in AoE1 or AoE2.
+    ParseStartingAgeError(ParseStartingAgeError),
+    /// An error occurred while reading or writing.
+    IoError(io::Error),
+}
+
+impl From<io::Error> for Error {
+    fn from(err: io::Error) -> Error {
+        Error::IoError(err)
+    }
+}
+
+impl From<util::ReadStringError> for Error {
+    fn from(err: util::ReadStringError) -> Error {
+        match err {
+            util::ReadStringError::IoError(err) => Error::IoError(err),
+            util::ReadStringError::DecodeStringError(err) => Error::DecodeStringError(err),
+        }
+    }
+}
+
+impl From<util::WriteStringError> for Error {
+    fn from(err: util::WriteStringError) -> Error {
+        match err {
+            util::WriteStringError::IoError(err) => Error::IoError(err),
+            util::WriteStringError::EncodeStringError(err) => Error::EncodeStringError(err),
+        }
+    }
+}
+
+macro_rules! error_impl_from {
+    ($from:ident) => {
+        impl From<$from> for Error {
+            fn from(err: $from) -> Error {
+                Error::$from(err)
+            }
+        }
+    };
+}
+
+error_impl_from!(ParseDiplomaticStanceError);
+error_impl_from!(ParseDataSetError);
+error_impl_from!(ParseDLCPackageError);
+error_impl_from!(ParseStartingAgeError);
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self {
+            Error::MissingFileNameError => write!(f, "must have a file name"),
+            Error::UnsupportedFormatVersionError(version) => {
+                write!(f, "unsupported format version {:?}", version)
+            }
+            Error::TooManyDisabledTechsError(n) => write!(
+                f,
+                "too many disabled techs: got {}, but requested version supports up to 20",
+                n
+            ),
+            Error::TooManyDisabledBuildingsError(n, max) => write!(
+                f,
+                "too many disabled buildings: got {}, but requested version supports up to {}",
+                n, max
+            ),
+            Error::CannotDisableTechsError => {
+                write!(f, "requested version does not support disabling techs")
+            }
+            Error::CannotDisableUnitsError => {
+                write!(f, "requested version does not support disabling units")
+            }
+            Error::CannotDisableBuildingsError => {
+                write!(f, "requested version does not support disabling buildings")
+            }
+            Error::IoError(err) => write!(f, "{}", err),
+            Error::DecodeStringError(err) => write!(f, "{}", err),
+            Error::EncodeStringError(err) => write!(f, "{}", err),
+            Error::ParseDiplomaticStanceError(err) => write!(f, "{}", err),
+            Error::ParseDataSetError(err) => write!(f, "{}", err),
+            Error::ParseDLCPackageError(err) => write!(f, "{}", err),
+            Error::ParseStartingAgeError(err) => write!(f, "{}", err),
+        }
+    }
+}
+
+impl std::error::Error for Error {}
+
+/// Result type for SCX methods.
+pub type Result<T> = std::result::Result<T, Error>;
 
 /// A Scenario file.
 pub struct Scenario {

--- a/crates/genie-scx/src/map.rs
+++ b/crates/genie-scx/src/map.rs
@@ -2,6 +2,7 @@ use crate::Result;
 use byteorder::{ReadBytesExt, WriteBytesExt, LE};
 use std::io::{Read, Write};
 
+/// A map tile.
 #[derive(Debug)]
 pub struct Tile {
     /// The terrain.
@@ -12,6 +13,7 @@ pub struct Tile {
     pub zone: i8,
 }
 
+/// Describes the terrain in a map.
 #[derive(Debug)]
 pub struct Map {
     /// Width of this map in tiles.
@@ -67,30 +69,42 @@ impl Map {
         Ok(())
     }
 
+    /// Get the width of the map.
     pub fn width(&self) -> u32 {
         self.width
     }
 
+    /// Get the height of the map.
     pub fn height(&self) -> u32 {
         self.height
     }
 
+    /// Get a tile at the given coordinates.
+    ///
+    /// If the coordinates are out of bounds, returns None.
     pub fn tile(&self, x: u32, y: u32) -> Option<&Tile> {
         self.tiles
             .get(y as usize)
             .and_then(|row| row.get(x as usize))
     }
 
+    /// Get a mutable reference to the tile at the given coordinates.
+    ///
+    /// If the coordinates are out of bounds, returns None.
     pub fn tile_mut(&mut self, x: u32, y: u32) -> Option<&mut Tile> {
         self.tiles
             .get_mut(y as usize)
             .and_then(|row| row.get_mut(x as usize))
     }
 
+    /// Iterate over all the tiles.
     pub fn tiles(&self) -> impl Iterator<Item = &Tile> {
         self.tiles.iter().map(|row| row.iter()).flatten()
     }
 
+    /// Iterate over all the tiles, with mutable references.
+    ///
+    /// This is handy if you want to replace terrains throughout the entire map, for example.
     pub fn tiles_mut(&mut self) -> impl Iterator<Item = &mut Tile> {
         self.tiles.iter_mut().map(|row| row.iter_mut()).flatten()
     }

--- a/crates/genie-scx/src/map.rs
+++ b/crates/genie-scx/src/map.rs
@@ -1,5 +1,6 @@
+use crate::Result;
 use byteorder::{ReadBytesExt, WriteBytesExt, LE};
-use std::io::{Read, Result, Write};
+use std::io::{Read, Write};
 
 #[derive(Debug)]
 pub struct Tile {

--- a/crates/genie-scx/src/player.rs
+++ b/crates/genie-scx/src/player.rs
@@ -1,7 +1,8 @@
 use crate::util::*;
 use crate::victory::VictoryConditions;
+use crate::Result;
 use byteorder::{ReadBytesExt, WriteBytesExt, LE};
-use std::io::{Read, Result, Write};
+use std::io::{Read, Write};
 
 #[derive(Debug)]
 pub struct PlayerBaseProperties {

--- a/crates/genie-scx/src/triggers.rs
+++ b/crates/genie-scx/src/triggers.rs
@@ -1,6 +1,7 @@
 use crate::util::*;
+use crate::Result;
 use byteorder::{ReadBytesExt, WriteBytesExt, LE};
-use std::io::{Read, Result, Write};
+use std::io::{Read, Write};
 
 #[derive(Debug)]
 pub struct TriggerCondition {

--- a/crates/genie-scx/src/types.rs
+++ b/crates/genie-scx/src/types.rs
@@ -6,6 +6,7 @@ use std::result::Result;
 /// SCX Format version.
 pub type SCXVersion = [u8; 4];
 
+/// Could not parse a diplomatic stance because given number is an unknown stance ID.
 #[derive(Debug, Clone, Copy)]
 pub struct ParseDiplomaticStanceError(i32);
 
@@ -45,6 +46,7 @@ impl From<DiplomaticStance> for i32 {
     }
 }
 
+/// Could not parse a data set because given number is an unknown data set ID.
 #[derive(Debug, Clone, Copy)]
 pub struct ParseDataSetError(i32);
 
@@ -81,6 +83,7 @@ impl From<DataSet> for i32 {
     }
 }
 
+/// Could not parse a DLC package identifier because given number is an unknown DLC ID.
 #[derive(Debug, Clone, Copy)]
 pub struct ParseDLCPackageError(i32);
 
@@ -92,6 +95,7 @@ impl std::fmt::Display for ParseDLCPackageError {
 
 impl std::error::Error for ParseDLCPackageError {}
 
+/// An HD Edition DLC identifier.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DLCPackage {
     AgeOfKings,
@@ -126,6 +130,7 @@ impl From<DLCPackage> for i32 {
     }
 }
 
+/// Could not parse a starting age because given number refers to an unknown age.
 #[derive(Debug, Clone, Copy)]
 pub struct ParseStartingAgeError {
     version: f32,

--- a/crates/genie-scx/src/types.rs
+++ b/crates/genie-scx/src/types.rs
@@ -1,10 +1,21 @@
 //! Contains pure types, no IO.
 //!
 //! Most of these are more descriptive wrappers around integers.
-use std::io::{Error, ErrorKind, Result};
+use std::result::Result;
 
 /// SCX Format version.
 pub type SCXVersion = [u8; 4];
+
+#[derive(Debug, Clone, Copy)]
+pub struct ParseDiplomaticStanceError(i32);
+
+impl std::fmt::Display for ParseDiplomaticStanceError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "invalid diplomatic stance {} (must be 0/1/3)", self.0)
+    }
+}
+
+impl std::error::Error for ParseDiplomaticStanceError {}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DiplomaticStance {
@@ -14,15 +25,12 @@ pub enum DiplomaticStance {
 }
 
 impl DiplomaticStance {
-    pub fn try_from(n: i32) -> Result<Self> {
+    pub fn try_from(n: i32) -> Result<Self, ParseDiplomaticStanceError> {
         match n {
             0 => Ok(DiplomaticStance::Ally),
             1 => Ok(DiplomaticStance::Neutral),
             3 => Ok(DiplomaticStance::Enemy),
-            _ => Err(Error::new(
-                ErrorKind::Other,
-                format!("invalid diplomatic stance {} (must be 0/1/3)", n),
-            )),
+            n => Err(ParseDiplomaticStanceError(n)),
         }
     }
 }
@@ -37,6 +45,17 @@ impl From<DiplomaticStance> for i32 {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct ParseDataSetError(i32);
+
+impl std::fmt::Display for ParseDataSetError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "invalid data set {} (must be 0/1)", self.0)
+    }
+}
+
+impl std::error::Error for ParseDataSetError {}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DataSet {
     BaseGame,
@@ -44,11 +63,11 @@ pub enum DataSet {
 }
 
 impl DataSet {
-    pub fn try_from(n: i32) -> Result<Self> {
+    pub fn try_from(n: i32) -> Result<Self, ParseDataSetError> {
         match n {
             0 => Ok(DataSet::BaseGame),
             1 => Ok(DataSet::Expansions),
-            _ => Err(Error::new(ErrorKind::Other, "unknown data set")),
+            n => Err(ParseDataSetError(n)),
         }
     }
 }
@@ -62,6 +81,17 @@ impl From<DataSet> for i32 {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
+pub struct ParseDLCPackageError(i32);
+
+impl std::fmt::Display for ParseDLCPackageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "unknown dlc package {}", self.0)
+    }
+}
+
+impl std::error::Error for ParseDLCPackageError {}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DLCPackage {
     AgeOfKings,
@@ -72,14 +102,14 @@ pub enum DLCPackage {
 }
 
 impl DLCPackage {
-    pub fn try_from(n: i32) -> Result<Self> {
+    pub fn try_from(n: i32) -> Result<Self, ParseDLCPackageError> {
         match n {
             2 => Ok(DLCPackage::AgeOfKings),
             3 => Ok(DLCPackage::AgeOfConquerors),
             4 => Ok(DLCPackage::TheForgotten),
             5 => Ok(DLCPackage::AfricanKingdoms),
             6 => Ok(DLCPackage::RiseOfTheRajas),
-            _ => Err(Error::new(ErrorKind::Other, "unknown dlc package")),
+            n => Err(ParseDLCPackageError(n)),
         }
     }
 }
@@ -95,6 +125,25 @@ impl From<DLCPackage> for i32 {
         }
     }
 }
+
+#[derive(Debug, Clone, Copy)]
+pub struct ParseStartingAgeError {
+    version: f32,
+    found: i32,
+}
+
+impl std::fmt::Display for ParseStartingAgeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let expected = if self.version < 1.25 { "-1-4" } else { "-1-6" };
+        write!(
+            f,
+            "invalid starting age {} (must be {})",
+            self.found, expected
+        )
+    }
+}
+
+impl std::error::Error for ParseStartingAgeError {}
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum StartingAge {
@@ -117,7 +166,7 @@ pub enum StartingAge {
 impl StartingAge {
     /// Convert a starting age number to the appropriate enum for a particular
     /// data version.
-    pub fn try_from(n: i32, version: f32) -> Result<Self> {
+    pub fn try_from(n: i32, version: f32) -> Result<Self, ParseStartingAgeError> {
         if version < 1.25 {
             match n {
                 -1 => Ok(StartingAge::Default),
@@ -126,10 +175,7 @@ impl StartingAge {
                 2 => Ok(StartingAge::CastleAge),
                 3 => Ok(StartingAge::ImperialAge),
                 4 => Ok(StartingAge::PostImperialAge),
-                _ => Err(Error::new(
-                    ErrorKind::Other,
-                    format!("invalid starting age {} (must be -1-4)", n),
-                )),
+                _ => Err(ParseStartingAgeError { version, found: n }),
             }
         } else {
             match n {
@@ -140,10 +186,7 @@ impl StartingAge {
                 4 => Ok(StartingAge::CastleAge),
                 5 => Ok(StartingAge::ImperialAge),
                 6 => Ok(StartingAge::PostImperialAge),
-                _ => Err(Error::new(
-                    ErrorKind::Other,
-                    format!("invalid starting age {} (must be -1-6)", n),
-                )),
+                _ => Err(ParseStartingAgeError { version, found: n }),
             }
         }
     }

--- a/crates/genie-scx/src/util.rs
+++ b/crates/genie-scx/src/util.rs
@@ -2,6 +2,10 @@ use byteorder::{WriteBytesExt, LE};
 use encoding_rs::WINDOWS_1252;
 use std::io::{self, Read, Write};
 
+/// Failed to decode a string as WINDOWS-1252.
+///
+/// This means that the scenario file contained a string that could not be decoded using the
+/// WINDOWS-1252 code page. In the future, genie-scx will support other encodings.
 #[derive(Debug, Clone, Copy)]
 pub struct DecodeStringError;
 
@@ -13,6 +17,9 @@ impl std::fmt::Display for DecodeStringError {
 
 impl std::error::Error for DecodeStringError {}
 
+/// Failed to encode a string as WINDOWS-1252.
+///
+/// This means that a string could not be encoded using the WINDOWS-1252 code page. In the future, genie-scx will support other encodings.
 #[derive(Debug, Clone, Copy)]
 pub struct EncodeStringError;
 
@@ -24,9 +31,12 @@ impl std::fmt::Display for EncodeStringError {
 
 impl std::error::Error for EncodeStringError {}
 
+/// Failed to read a string.
 #[derive(Debug)]
 pub enum ReadStringError {
+    /// Failed to read a string because the bytes could not be decoded.
     DecodeStringError(DecodeStringError),
+    /// Failed to read a string because the underlying I/O failed.
     IoError(io::Error),
 }
 impl From<io::Error> for ReadStringError {
@@ -35,9 +45,12 @@ impl From<io::Error> for ReadStringError {
     }
 }
 
+/// Failed to write a string.
 #[derive(Debug)]
 pub enum WriteStringError {
+    /// Failed to read a string because it could not be encoded.
     EncodeStringError(EncodeStringError),
+    /// Failed to write a string because the underlying I/O failed.
     IoError(std::io::Error),
 }
 impl From<io::Error> for WriteStringError {

--- a/crates/genie-scx/src/util.rs
+++ b/crates/genie-scx/src/util.rs
@@ -1,8 +1,52 @@
 use byteorder::{WriteBytesExt, LE};
 use encoding_rs::WINDOWS_1252;
-use std::io::{Error, ErrorKind, Read, Result, Write};
+use std::io::{self, Read, Write};
 
-pub fn read_str<R: Read>(input: &mut R, length: usize) -> Result<Option<String>> {
+#[derive(Debug, Clone, Copy)]
+pub struct DecodeStringError;
+
+impl std::fmt::Display for DecodeStringError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "could not decode string as WINDOWS-1252")
+    }
+}
+
+impl std::error::Error for DecodeStringError {}
+
+#[derive(Debug, Clone, Copy)]
+pub struct EncodeStringError;
+
+impl std::fmt::Display for EncodeStringError {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "could not encode string as WINDOWS-1252")
+    }
+}
+
+impl std::error::Error for EncodeStringError {}
+
+#[derive(Debug)]
+pub enum ReadStringError {
+    DecodeStringError(DecodeStringError),
+    IoError(io::Error),
+}
+impl From<io::Error> for ReadStringError {
+    fn from(err: io::Error) -> ReadStringError {
+        ReadStringError::IoError(err)
+    }
+}
+
+#[derive(Debug)]
+pub enum WriteStringError {
+    EncodeStringError(EncodeStringError),
+    IoError(std::io::Error),
+}
+impl From<io::Error> for WriteStringError {
+    fn from(err: io::Error) -> WriteStringError {
+        WriteStringError::IoError(err)
+    }
+}
+
+pub fn read_str<R: Read>(input: &mut R, length: usize) -> Result<Option<String>, ReadStringError> {
     if length > 0 {
         let mut bytes = vec![0; length as usize];
         input.read_exact(&mut bytes)?;
@@ -14,7 +58,7 @@ pub fn read_str<R: Read>(input: &mut R, length: usize) -> Result<Option<String>>
         } else {
             let (result, _enc, failed) = WINDOWS_1252.decode(&bytes);
             if failed {
-                Err(Error::new(ErrorKind::Other, "invalid string"))
+                Err(ReadStringError::DecodeStringError(DecodeStringError))
             } else {
                 Ok(Some(result.to_string()))
             }
@@ -24,10 +68,10 @@ pub fn read_str<R: Read>(input: &mut R, length: usize) -> Result<Option<String>>
     }
 }
 
-pub fn write_str<W: Write>(output: &mut W, string: &str) -> Result<()> {
+pub fn write_str<W: Write>(output: &mut W, string: &str) -> Result<(), WriteStringError> {
     let (bytes, _enc, failed) = WINDOWS_1252.encode(string);
     if failed {
-        return Err(Error::new(ErrorKind::Other, "invalid string"));
+        return Err(WriteStringError::EncodeStringError(EncodeStringError));
     }
     assert!(bytes.len() < std::i16::MAX as usize);
     output.write_i16::<LE>(bytes.len() as i16 + 1)?;
@@ -36,10 +80,10 @@ pub fn write_str<W: Write>(output: &mut W, string: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn write_i32_str<W: Write>(output: &mut W, string: &str) -> Result<()> {
+pub fn write_i32_str<W: Write>(output: &mut W, string: &str) -> Result<(), WriteStringError> {
     let (bytes, _enc, failed) = WINDOWS_1252.encode(string);
     if failed {
-        return Err(Error::new(ErrorKind::Other, "invalid string"));
+        return Err(WriteStringError::EncodeStringError(EncodeStringError));
     }
     assert!(bytes.len() < std::i32::MAX as usize);
     output.write_i32::<LE>(bytes.len() as i32 + 1)?;
@@ -48,7 +92,10 @@ pub fn write_i32_str<W: Write>(output: &mut W, string: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn write_opt_str<W: Write>(output: &mut W, option: &Option<String>) -> Result<()> {
+pub fn write_opt_str<W: Write>(
+    output: &mut W,
+    option: &Option<String>,
+) -> Result<(), WriteStringError> {
     if let Some(ref string) = option {
         write_str(output, &string)
     } else {
@@ -57,7 +104,10 @@ pub fn write_opt_str<W: Write>(output: &mut W, option: &Option<String>) -> Resul
     }
 }
 
-pub fn write_opt_i32_str<W: Write>(output: &mut W, option: &Option<String>) -> Result<()> {
+pub fn write_opt_i32_str<W: Write>(
+    output: &mut W,
+    option: &Option<String>,
+) -> Result<(), WriteStringError> {
     if let Some(ref string) = option {
         write_i32_str(output, &string)
     } else {

--- a/crates/genie-scx/src/victory.rs
+++ b/crates/genie-scx/src/victory.rs
@@ -1,5 +1,6 @@
+use crate::Result;
 use byteorder::{ReadBytesExt, WriteBytesExt, LE};
-use std::io::{Read, Result, Write};
+use std::io::{Read, Write};
 
 /// AoE1's victory info.
 ///


### PR DESCRIPTION
#3 does this for lang and hki, this PR intends to do it for the other things

breaking change for both scx (will be 2.0) and cpx (will be minor bump) so far

- [x] scx
- [x] cpx (read is ~done, need to handle write errors)
- [ ] drs