### PR TITLE
drs: add writer

### DIFF
--- a/crates/genie-drs/src/lib.rs
+++ b/crates/genie-drs/src/lib.rs
@@ -19,10 +19,16 @@
 //! }
 //! ```
 
-use byteorder::{ReadBytesExt, LE};
-use std::io::{Error, ErrorKind, Read, Seek, SeekFrom};
+use byteorder::{ReadBytesExt, WriteBytesExt, LE};
+use std::io::{Error, Read, Write};
 use std::slice;
 use std::str;
+
+mod read;
+mod write;
+
+pub use read::DRSReader;
+pub use write::{DRSWriter, Strategy as WriteStrategy};
 
 /// A DRS version string.
 type DRSVersion = [u8; 4];
@@ -62,6 +68,15 @@ impl DRSHeader {
             num_resource_types,
             directory_size,
         })
+    }
+
+    pub fn write_to<W: Write>(&self, output: &mut W) -> Result<(), Error> {
+        output.write_all(&self.banner_msg)?;
+        output.write_all(&self.version)?;
+        output.write_all(&self.password)?;
+        output.write_u32::<LE>(self.num_resource_types)?;
+        output.write_u32::<LE>(self.directory_size)?;
+        Ok(())
     }
 }
 
@@ -105,6 +120,13 @@ impl DRSTable {
         })
     }
 
+    fn write_to<W: Write>(&self, output: &mut W) -> Result<(), Error> {
+        output.write_all(&self.resource_type)?;
+        output.write_u32::<LE>(self.offset)?;
+        output.write_u32::<LE>(self.num_resources)?;
+        Ok(())
+    }
+
     /// Read the table itself.
     fn read_resources<R: Read>(&mut self, source: &mut R) -> Result<(), Error> {
         for _ in 0..self.num_resources {
@@ -138,6 +160,12 @@ impl DRSTable {
         resource_type.clone_from_slice(&self.resource_type);
         resource_type.reverse();
         str::from_utf8(&resource_type).unwrap().trim().to_string()
+    }
+
+    pub(crate) fn add(&mut self, res: DRSResource) -> &mut DRSResource {
+        self.resources.push(res);
+        self.num_resources += 1;
+        self.resources.last_mut().unwrap()
     }
 }
 
@@ -175,108 +203,17 @@ impl DRSResource {
         let size = source.read_u32::<LE>()?;
         Ok(DRSResource { id, offset, size })
     }
+
+    fn write_to<W: Write>(&self, output: &mut W) -> Result<(), Error> {
+        output.write_u32::<LE>(self.id)?;
+        output.write_u32::<LE>(self.offset)?;
+        output.write_u32::<LE>(self.size)?;
+        Ok(())
+    }
 }
 
 pub type DRSTableIterator<'a> = slice::Iter<'a, DRSTable>;
 pub type DRSResourceIterator<'a> = slice::Iter<'a, DRSResource>;
-
-/// A DRS archive reader.
-#[derive(Debug)]
-pub struct DRSReader {
-    header: Option<DRSHeader>,
-    tables: Vec<DRSTable>,
-}
-
-impl DRSReader {
-    /// Create a new DRS archive reader for the given handle.
-    /// The handle must be `Read`able and `Seek`able.
-    pub fn new<R>(handle: &mut R) -> Result<DRSReader, Error>
-    where
-        R: Read + Seek,
-    {
-        let mut drs = DRSReader {
-            header: None,
-            tables: vec![],
-        };
-        drs.read_header(handle)?;
-        drs.read_tables(handle)?;
-        drs.read_dictionary(handle)?;
-        Ok(drs)
-    }
-
-    /// Read the DRS archive header.
-    fn read_header<R: Read + Seek>(&mut self, handle: &mut R) -> Result<(), Error> {
-        self.header = Some(DRSHeader::from(handle)?);
-        Ok(())
-    }
-
-    /// Read the list of tables.
-    fn read_tables<R: Read + Seek>(&mut self, handle: &mut R) -> Result<(), Error> {
-        match self.header {
-            Some(ref header) => {
-                for _ in 0..header.num_resource_types {
-                    let table = DRSTable::from(handle)?;
-                    self.tables.push(table);
-                }
-            }
-            None => panic!("must read header first"),
-        };
-        Ok(())
-    }
-
-    /// Read the list of resources.
-    fn read_dictionary<R: Read + Seek>(&mut self, handle: &mut R) -> Result<(), Error> {
-        for table in &mut self.tables {
-            table.read_resources(handle)?;
-        }
-        Ok(())
-    }
-
-    /// Get the table for the given resource type.
-    pub fn get_table(&self, resource_type: ResourceType) -> Option<&DRSTable> {
-        self.tables
-            .iter()
-            .find(|table| table.resource_type == resource_type)
-    }
-
-    /// Get a resource of a given type and ID.
-    pub fn get_resource(&self, resource_type: ResourceType, id: u32) -> Option<&DRSResource> {
-        self.get_table(resource_type)
-            .and_then(|table| table.get_resource(id))
-    }
-
-    /// Get the type of a resource with the given ID.
-    pub fn get_resource_type(&self, id: u32) -> Option<ResourceType> {
-        self.tables
-            .iter()
-            .find(|table| table.get_resource(id).is_some())
-            .map(|table| table.resource_type)
-    }
-
-    /// Read a file from the DRS archive.
-    pub fn read_resource<R: Read + Seek>(
-        &self,
-        handle: &mut R,
-        resource_type: ResourceType,
-        id: u32,
-    ) -> Result<Box<[u8]>, Error> {
-        let &DRSResource { size, offset, .. } = self
-            .get_resource(resource_type, id)
-            .ok_or_else(|| Error::new(ErrorKind::NotFound, "Resource not found in this archive"))?;
-
-        handle.seek(SeekFrom::Start(u64::from(offset)))?;
-
-        let mut buf = vec![0 as u8; size as usize];
-        handle.read_exact(&mut buf)?;
-
-        Ok(buf.into_boxed_slice())
-    }
-
-    /// Iterate over the tables in this DRS archive.
-    pub fn tables(&self) -> DRSTableIterator {
-        self.tables.iter()
-    }
-}
 
 #[cfg(test)]
 mod tests {

--- a/crates/genie-drs/src/read.rs
+++ b/crates/genie-drs/src/read.rs
@@ -94,6 +94,7 @@ impl DRSReader {
     }
 
     /// Iterate over the tables in this DRS archive.
+    #[inline]
     pub fn tables(&self) -> DRSTableIterator {
         self.tables.iter()
     }

--- a/crates/genie-drs/src/read.rs
+++ b/crates/genie-drs/src/read.rs
@@ -1,0 +1,100 @@
+use super::{DRSHeader, DRSResource, DRSTable, DRSTableIterator, ResourceType};
+use std::io::{Error, ErrorKind, Read, Seek, SeekFrom};
+
+/// A DRS archive reader.
+#[derive(Debug)]
+pub struct DRSReader {
+    header: Option<DRSHeader>,
+    tables: Vec<DRSTable>,
+}
+
+impl DRSReader {
+    /// Create a new DRS archive reader for the given handle.
+    /// The handle must be `Read`able and `Seek`able.
+    pub fn new<R>(handle: &mut R) -> Result<DRSReader, Error>
+    where
+        R: Read + Seek,
+    {
+        let mut drs = DRSReader {
+            header: None,
+            tables: vec![],
+        };
+        drs.read_header(handle)?;
+        drs.read_tables(handle)?;
+        drs.read_dictionary(handle)?;
+        Ok(drs)
+    }
+
+    /// Read the DRS archive header.
+    fn read_header<R: Read + Seek>(&mut self, handle: &mut R) -> Result<(), Error> {
+        self.header = Some(DRSHeader::from(handle)?);
+        Ok(())
+    }
+
+    /// Read the list of tables.
+    fn read_tables<R: Read + Seek>(&mut self, handle: &mut R) -> Result<(), Error> {
+        match self.header {
+            Some(ref header) => {
+                for _ in 0..header.num_resource_types {
+                    let table = DRSTable::from(handle)?;
+                    self.tables.push(table);
+                }
+            }
+            None => panic!("must read header first"),
+        };
+        Ok(())
+    }
+
+    /// Read the list of resources.
+    fn read_dictionary<R: Read + Seek>(&mut self, handle: &mut R) -> Result<(), Error> {
+        for table in &mut self.tables {
+            table.read_resources(handle)?;
+        }
+        Ok(())
+    }
+
+    /// Get the table for the given resource type.
+    pub fn get_table(&self, resource_type: ResourceType) -> Option<&DRSTable> {
+        self.tables
+            .iter()
+            .find(|table| table.resource_type == resource_type)
+    }
+
+    /// Get a resource of a given type and ID.
+    pub fn get_resource(&self, resource_type: ResourceType, id: u32) -> Option<&DRSResource> {
+        self.get_table(resource_type)
+            .and_then(|table| table.get_resource(id))
+    }
+
+    /// Get the type of a resource with the given ID.
+    pub fn get_resource_type(&self, id: u32) -> Option<ResourceType> {
+        self.tables
+            .iter()
+            .find(|table| table.get_resource(id).is_some())
+            .map(|table| table.resource_type)
+    }
+
+    /// Read a file from the DRS archive.
+    pub fn read_resource<R: Read + Seek>(
+        &self,
+        handle: &mut R,
+        resource_type: ResourceType,
+        id: u32,
+    ) -> Result<Box<[u8]>, Error> {
+        let &DRSResource { size, offset, .. } = self
+            .get_resource(resource_type, id)
+            .ok_or_else(|| Error::new(ErrorKind::NotFound, "Resource not found in this archive"))?;
+
+        handle.seek(SeekFrom::Start(u64::from(offset)))?;
+
+        let mut buf = vec![0 as u8; size as usize];
+        handle.read_exact(&mut buf)?;
+
+        Ok(buf.into_boxed_slice())
+    }
+
+    /// Iterate over the tables in this DRS archive.
+    pub fn tables(&self) -> DRSTableIterator {
+        self.tables.iter()
+    }
+}

--- a/crates/genie-drs/src/write.rs
+++ b/crates/genie-drs/src/write.rs
@@ -1,0 +1,182 @@
+use byteorder::{WriteBytesExt, LE};
+use crate::{DRSHeader, DRSResource, DRSTable, ResourceType};
+use std::io::{Read, Result, Seek, SeekFrom, Write};
+
+/// Strategy to use when writing files to the archive.
+pub enum Strategy {
+    /// Create the entire DRS file in memory first, then flush it to the output.
+    ///
+    /// This works best for archives with small files.
+    InMemory,
+    /// Reserve space for metadata for the given amount of tables and files at the top of the file, then fill
+    /// it in at the end.
+    ///
+    /// The first number is the amount of tables, the second is the amount of files.
+    ReserveDirectory(u32, u32),
+}
+
+impl Default for Strategy {
+    /// Reserves space for 65536 files spread across 10 tables, meaning a directory size of about 768KiB.
+    fn default() -> Self {
+        Strategy::ReserveDirectory(10, 65536)
+    }
+}
+
+pub struct DRSWriter<W>
+where
+    W: Write + Seek,
+{
+    inner: W,
+    header: DRSHeader,
+    tables: Vec<DRSTable>,
+    resources: Vec<Vec<u8>>,
+    write_offset: u32,
+    strategy: Strategy,
+}
+
+impl<W> DRSWriter<W>
+where
+    W: Write + Seek,
+{
+    pub fn new(output: W, strategy: Strategy) -> Result<Self> {
+        let header = DRSHeader {
+            banner_msg: *b"Copyright (c) 1997 Ensemble Studios.\x1a\x00\x00\x00",
+            version: *b"1.00",
+            password: *b"tribe\x00\x00\x00\x00\x00\x00\x00",
+            num_resource_types: 0,
+            directory_size: 0,
+        };
+
+        let mut writer = Self {
+            inner: output,
+            header,
+            tables: vec![],
+            resources: if let Strategy::InMemory = strategy {
+                vec![]
+            } else {
+                Vec::with_capacity(0)
+            },
+            write_offset: 0,
+            strategy,
+        };
+
+        writer.write_reserved()?;
+
+        Ok(writer)
+    }
+
+    pub fn into_inner(self) -> W {
+        self.inner
+    }
+
+    fn write_reserved(&mut self) -> Result<()> {
+        if let Strategy::ReserveDirectory(tables, files) = self.strategy {
+            self.header.directory_size = 64 + 12 * (tables + files);
+            self.write_header()?;
+            let reserved = vec![0; self.header.directory_size as usize - 64];
+            self.inner.write_all(&reserved)?;
+            self.write_offset = self.header.directory_size;
+        }
+        Ok(())
+    }
+
+    fn write_header(&mut self) -> Result<()> {
+        self.header.write_to(&mut self.inner)
+    }
+
+    fn write_tables(&mut self) -> Result<()> {
+        for table in &self.tables {
+            table.write_to(&mut self.inner)?;
+        }
+        for table in &self.tables {
+            for resource in table.resources() {
+                resource.write_to(&mut self.inner)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn add(&mut self, t: ResourceType, id: u32, mut data: impl Read) -> Result<()> {
+        let res = DRSResource {
+            id,
+            offset: 0, // TBD
+            size: 0,   // TBD
+        };
+
+        let res = match self
+            .tables
+            .iter_mut()
+            .find(|table| table.resource_type == t)
+        {
+            Some(table) => table.add(res),
+            None => {
+                let mut table = DRSTable {
+                    resource_type: t,
+                    offset: 0, // TBD
+                    num_resources: 0,
+                    resources: vec![],
+                };
+                table.add(res);
+                self.tables.push(table);
+                self.tables.last_mut().unwrap().resources.last_mut().unwrap()
+            }
+        };
+
+        match self.strategy {
+            Strategy::InMemory => {
+                let mut bytes = vec![];
+                data.read_to_end(&mut bytes)?;
+                assert!(bytes.len() < u32::max_value() as usize);
+                res.size = bytes.len() as u32;
+                self.resources.push(bytes);
+            }
+            Strategy::ReserveDirectory(_, _) => {
+                let len = std::io::copy(&mut data, &mut self.inner)?;
+                assert!(len < u32::max_value() as u64);
+                res.offset = self.write_offset;
+                res.size = len as u32;
+                self.write_offset += res.size;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn flush(mut self) -> Result<W> {
+        if let Strategy::ReserveDirectory(_, _) = self.strategy {
+            // Update the resource type count
+            assert!(self.tables.len() < u32::max_value() as usize);
+            let num_resource_types = self.tables.len() as u32;
+            self.inner.seek(SeekFrom::Start(56))?;
+            self.inner.write_u32::<LE>(num_resource_types)?;
+            self.inner.seek(SeekFrom::Current(4))?;
+
+            // Assign table offsets
+            let mut table_offset = 64 + 12 * (self.tables.len() as u32);
+            for table in self.tables.iter_mut() {
+                table.offset = table_offset;
+                table_offset += 12 * (table.len() as u32);
+            }
+
+            // Write out all the table data
+            self.write_tables()?;
+            self.inner.seek(SeekFrom::End(0))?;
+        }
+
+        Ok(self.inner)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::fs::File;
+
+    #[test]
+    fn basic() {
+        let f = File::create("/tmp/x.drs").unwrap();
+        let mut drs = DRSWriter::new(f, Strategy::ReserveDirectory(1, 1)).unwrap();
+        drs.add(*b" txt", 1, "example test file".as_bytes()).unwrap();
+        drs.flush().unwrap();
+    }
+}

--- a/crates/genie-drs/src/write.rs
+++ b/crates/genie-drs/src/write.rs
@@ -88,8 +88,13 @@ where
         drs.write_tables()?;
 
         for table in &drs.tables {
-            let mut data = self.resources.iter()
-                .filter_map(|(t, bytes)| if table.resource_type == *t { Some(bytes) } else { None });
+            let mut data = self.resources.iter().filter_map(|(t, bytes)| {
+                if table.resource_type == *t {
+                    Some(bytes)
+                } else {
+                    None
+                }
+            });
             for _ in &table.resources {
                 let bytes = data.next().expect("genie-drs bug: mismatch between InMemoryStrategy resources and DRSWriter table data");
                 drs.output.write_all(&bytes)?;

--- a/crates/genie-drs/src/write.rs
+++ b/crates/genie-drs/src/write.rs
@@ -3,6 +3,16 @@ use byteorder::{WriteBytesExt, LE};
 use std::io::{Read, Result, Seek, SeekFrom, Write};
 
 /// Strategy to use when writing files to the archive.
+///
+/// DRS files contain metadata at the start of the archive, and the size of this metadata depends
+/// on the number of files, the different types of files, and the sizes of the files that are added
+/// to the archive. To correctly write an archive to disk, we need to know the number and sizes of
+/// files before writing the header, and we only know where to put the files once the size of the
+/// header is known. In practice, this means we have to keep the entire archive in memory before
+/// writing it.
+///
+/// There are tricks to work around this and reduce memory usage. The `InMemory` strategy keeps the
+/// file in memory before writing it and is great for small archives. The other strateg(y|ies) start writing files without needing to keep them entirely in memory, with other tradeoffs.
 pub enum Strategy {
     /// Create the entire DRS file in memory first, then flush it to the output.
     ///
@@ -16,12 +26,26 @@ pub enum Strategy {
 }
 
 impl Default for Strategy {
-    /// Reserves space for 65536 files spread across 10 tables, meaning a directory size of about 768KiB.
+    /// The default strategy reserves space for 65536 files spread across 10 tables, meaning a directory size of about 768KiB.
     fn default() -> Self {
         Strategy::ReserveDirectory(10, 65536)
     }
 }
 
+/// Generator for .drs archives.
+///
+/// ```rust
+/// use std::{io::Cursor, fs::File};
+/// use genie_drs::{DRSWriter, WriteStrategy};
+/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// let buf = Cursor::new(vec![]);
+/// let mut writer = DRSWriter::new(buf, WriteStrategy::InMemory)?;
+/// writer.add("bina", 50500, "JASC-PAL\r\n0100\r\n...".as_bytes())?;
+/// writer.add("slp", 2, &b"some bytes"[..])?;
+/// let buf = writer.flush()?;
+/// // → a Vec<u8> containing the DRS file
+/// # Ok(()) }
+/// ```
 pub struct DRSWriter<W>
 where
     W: Write + Seek,
@@ -38,6 +62,7 @@ impl<W> DRSWriter<W>
 where
     W: Write + Seek,
 {
+    /// Create a writer with the given strategy.
     pub fn new(output: W, strategy: Strategy) -> Result<Self> {
         let header = DRSHeader {
             banner_msg: *b"Copyright (c) 1997 Ensemble Studios.\x1a\x00\x00\x00",
@@ -65,10 +90,7 @@ where
         Ok(writer)
     }
 
-    pub fn into_inner(self) -> W {
-        self.inner
-    }
-
+    /// Write 0 bytes for reserved space at the top of the file.
     fn write_reserved(&mut self) -> Result<()> {
         if let Strategy::ReserveDirectory(tables, files) = self.strategy {
             self.header.directory_size = 64 + 12 * (tables + files);
@@ -80,10 +102,12 @@ where
         Ok(())
     }
 
+    /// Write the .drs archive header.
     fn write_header(&mut self) -> Result<()> {
         self.header.write_to(&mut self.inner)
     }
 
+    /// Write the table and resource data.
     fn write_tables(&mut self) -> Result<()> {
         for table in &self.tables {
             table.write_to(&mut self.inner)?;
@@ -96,7 +120,13 @@ where
         Ok(())
     }
 
-    pub fn add(&mut self, t: ResourceType, id: u32, mut data: impl Read) -> Result<()> {
+    /// Add a file to the archive.
+    #[inline]
+    pub fn add(&mut self, t: impl Into<ResourceType>, id: u32, data: impl Read) -> Result<()> {
+        self.add_inner(t.into(), id, data)
+    }
+
+    fn add_inner(&mut self, t: ResourceType, id: u32, mut data: impl Read) -> Result<()> {
         let res = DRSResource {
             id,
             offset: 0, // TBD
@@ -131,13 +161,13 @@ where
             Strategy::InMemory => {
                 let mut bytes = vec![];
                 data.read_to_end(&mut bytes)?;
-                assert!(bytes.len() < u32::max_value() as usize);
+                assert!(bytes.len() < u32::max_value() as usize, "file too large");
                 res.size = bytes.len() as u32;
                 self.resources.push(bytes);
             }
             Strategy::ReserveDirectory(_, _) => {
                 let len = std::io::copy(&mut data, &mut self.inner)?;
-                assert!(len < u32::max_value() as u64);
+                assert!(len < u32::max_value() as u64, "file too large");
                 res.offset = self.write_offset;
                 res.size = len as u32;
                 self.write_offset += res.size;
@@ -147,25 +177,40 @@ where
         Ok(())
     }
 
+    /// Finish any writes that still need to happen and return the file handle.
     pub fn flush(mut self) -> Result<W> {
-        if let Strategy::ReserveDirectory(_, _) = self.strategy {
-            // Update the resource type count
-            assert!(self.tables.len() < u32::max_value() as usize);
-            let num_resource_types = self.tables.len() as u32;
-            self.inner.seek(SeekFrom::Start(56))?;
-            self.inner.write_u32::<LE>(num_resource_types)?;
-            self.inner.seek(SeekFrom::Current(4))?;
+        assert!(
+            self.tables.len() < u32::max_value() as usize,
+            "too many tables"
+        );
+        self.header.num_resource_types = self.tables.len() as u32;
 
-            // Assign table offsets
-            let mut table_offset = 64 + 12 * (self.tables.len() as u32);
-            for table in self.tables.iter_mut() {
-                table.offset = table_offset;
-                table_offset += 12 * (table.len() as u32);
+        match self.strategy {
+            Strategy::InMemory => {
+                assert!(
+                    self.resources.len() < u32::max_value() as usize,
+                    "too many resources"
+                );
+                self.header.directory_size = 64 + 12 * (self.tables.len() + self.resources.len()) as u32;
+                unimplemented!();
             }
+            Strategy::ReserveDirectory(_, _) => {
+                // Update the resource type count
+                self.inner.seek(SeekFrom::Start(56))?;
+                self.inner.write_u32::<LE>(self.header.num_resource_types)?;
+                self.inner.seek(SeekFrom::Current(4))?;
 
-            // Write out all the table data
-            self.write_tables()?;
-            self.inner.seek(SeekFrom::End(0))?;
+                // Assign table offsets
+                let mut table_offset = 64 + 12 * (self.tables.len() as u32);
+                for table in self.tables.iter_mut() {
+                    table.offset = table_offset;
+                    table_offset += 12 * (table.len() as u32);
+                }
+
+                // Write out all the table data
+                self.write_tables()?;
+                self.inner.seek(SeekFrom::End(0))?;
+            }
         }
 
         Ok(self.inner)
@@ -181,8 +226,7 @@ mod test {
     fn basic() {
         let f = File::create("/tmp/x.drs").unwrap();
         let mut drs = DRSWriter::new(f, Strategy::ReserveDirectory(1, 1)).unwrap();
-        drs.add(*b" txt", 1, "example test file".as_bytes())
-            .unwrap();
+        drs.add("txt", 1, "example test file".as_bytes()).unwrap();
         drs.flush().unwrap();
     }
 }

--- a/crates/genie-drs/src/write.rs
+++ b/crates/genie-drs/src/write.rs
@@ -1,6 +1,6 @@
 use crate::{DRSHeader, DRSResource, DRSTable, ResourceType};
 use byteorder::{WriteBytesExt, LE};
-use std::io::{Read, Result, Seek, SeekFrom, Write};
+use std::io::{self, Read, Seek, SeekFrom, Write};
 
 /// Strategy to use when writing files to the archive.
 ///
@@ -13,22 +13,206 @@ use std::io::{Read, Result, Seek, SeekFrom, Write};
 ///
 /// There are tricks to work around this and reduce memory usage. The `InMemory` strategy keeps the
 /// file in memory before writing it and is great for small archives. The other strateg(y|ies) start writing files without needing to keep them entirely in memory, with other tradeoffs.
-pub enum Strategy {
-    /// Create the entire DRS file in memory first, then flush it to the output.
-    ///
-    /// This works best for archives with small files.
-    InMemory,
-    /// Reserve space for metadata for the given amount of tables and files at the top of the file, then fill
-    /// it in at the end.
-    ///
-    /// The first number is the amount of tables, the second is the amount of files.
-    ReserveDirectory(u32, u32),
+pub trait Strategy<W>
+where
+    W: Write + Seek,
+{
+    fn open(&mut self, drs: &mut InnerDRSWriter<W>) -> Result<(), io::Error>;
+    fn add_resource<R: Read>(
+        &mut self,
+        drs: &mut InnerDRSWriter<W>,
+        table: ResourceType,
+        resource: DRSResource,
+        data: R,
+    ) -> Result<DRSResource, io::Error>;
+    fn close(self, drs: &mut InnerDRSWriter<W>) -> Result<(), io::Error>;
 }
 
-impl Default for Strategy {
+/// Create the entire DRS file in memory first, then flush it to the output.
+///
+/// This works best for archives with small files.
+#[derive(Default)]
+pub struct InMemoryStrategy {
+    resources: Vec<(ResourceType, Vec<u8>)>,
+}
+
+impl<W> Strategy<W> for InMemoryStrategy
+where
+    W: Write + Seek,
+{
+    fn open(&mut self, _drs: &mut InnerDRSWriter<W>) -> Result<(), io::Error> {
+        Ok(())
+    }
+
+    fn add_resource<R: Read>(
+        &mut self,
+        _drs: &mut InnerDRSWriter<W>,
+        table: ResourceType,
+        mut resource: DRSResource,
+        mut data: R,
+    ) -> Result<DRSResource, io::Error> {
+        let mut bytes = vec![];
+        data.read_to_end(&mut bytes)?;
+        assert!(bytes.len() < u32::max_value() as usize, "file too large");
+        resource.size = bytes.len() as u32;
+        self.resources.push((table, bytes));
+        Ok(resource)
+    }
+
+    fn close(self, drs: &mut InnerDRSWriter<W>) -> Result<(), io::Error> {
+        assert!(
+            self.resources.len() < u32::max_value() as usize,
+            "too many resources"
+        );
+
+        let num_tables = drs.tables.len();
+        let num_resources = drs.tables.iter().fold(0, |acc, t| acc + t.len());
+        drs.header.directory_size = 64 + 12 * (num_tables + num_resources) as u32;
+        drs.write_header()?;
+
+        // Assign table offsets
+        let mut table_offset = 64 + 12 * (drs.tables.len() as u32);
+        let mut file_offset = drs.header.directory_size;
+        for table in drs.tables.iter_mut() {
+            table.offset = table_offset;
+            table_offset += 12 * (table.len() as u32);
+
+            // Assign file offsets
+            for res in table.resources.iter_mut() {
+                res.offset = file_offset;
+                file_offset += res.size;
+            }
+        }
+
+        // Write out all the table data
+        drs.write_tables()?;
+
+        Ok(())
+    }
+}
+/// Writer strategy that reserve space for metadata for the given amount of tables and files at the top of the file, then fills it in at the end.
+pub struct ReserveDirectoryStrategy {
+    reserved_tables: u32,
+    file_space_left: u32,
+    write_offset: u32,
+}
+
+impl ReserveDirectoryStrategy {
+    /// Create a write strategy using a reserved metadata block.
+    ///
+    /// The strategy will support up to `reserved_tables` tables and `reserved_files` files.
+    /// The total size of the reserved metadata block will be `12 * (reserved_tables +
+    /// reserved_files)` bytes.
+    #[inline]
+    pub fn new(reserved_tables: u32, reserved_files: u32) -> Self {
+        Self {
+            reserved_tables,
+            file_space_left: reserved_files,
+            write_offset: 64 + 12 * (reserved_tables + reserved_files),
+        }
+    }
+}
+
+impl<W> Strategy<W> for ReserveDirectoryStrategy
+where
+    W: Write + Seek,
+{
+    fn open(&mut self, drs: &mut InnerDRSWriter<W>) -> Result<(), io::Error> {
+        drs.header.directory_size = self.write_offset;
+        drs.write_header()?;
+
+        // Write 0 bytes for reserved space at the top of the file.
+        let reserved_block = vec![0; self.write_offset as usize - 64];
+        drs.output.write_all(&reserved_block)?;
+        Ok(())
+    }
+
+    fn add_resource<R: Read>(
+        &mut self,
+        drs: &mut InnerDRSWriter<W>,
+        _table: ResourceType,
+        mut resource: DRSResource,
+        mut data: R,
+    ) -> Result<DRSResource, io::Error> {
+        assert!(self.file_space_left > 0, "too many files");
+        self.file_space_left -= 1;
+
+        let len = std::io::copy(&mut data, &mut drs.output)?;
+        assert!(len < u32::max_value() as u64, "file too large");
+        resource.offset = self.write_offset;
+        resource.size = len as u32;
+        self.write_offset += resource.size;
+        Ok(resource)
+    }
+
+    fn close(self, drs: &mut InnerDRSWriter<W>) -> Result<(), io::Error> {
+        assert!(
+            drs.tables.len() <= self.reserved_tables as usize,
+            "too many tables"
+        );
+
+        // Update the resource type count
+        drs.output.seek(SeekFrom::Start(56))?;
+        drs.output.write_u32::<LE>(drs.header.num_resource_types)?;
+        drs.output.seek(SeekFrom::Current(4))?;
+
+        // Assign table offsets
+        let mut table_offset = 64 + 12 * (drs.tables.len() as u32);
+        for table in drs.tables.iter_mut() {
+            table.offset = table_offset;
+            table_offset += 12 * (table.len() as u32);
+        }
+
+        // Write out all the table data
+        drs.write_tables()?;
+        drs.output.seek(SeekFrom::End(0))?;
+
+        Ok(())
+    }
+}
+
+impl Default for ReserveDirectoryStrategy {
     /// The default strategy reserves space for 65536 files spread across 10 tables, meaning a directory size of about 768KiB.
+    #[inline]
     fn default() -> Self {
-        Strategy::ReserveDirectory(10, 65536)
+        Self::new(10, 65536)
+    }
+}
+
+pub struct InnerDRSWriter<W>
+where
+    W: Write + Seek,
+{
+    output: W,
+    header: DRSHeader,
+    tables: Vec<DRSTable>,
+}
+
+impl<W> InnerDRSWriter<W>
+where
+    W: Write + Seek,
+{
+    /// Write the .drs archive header.
+    fn write_header(&mut self) -> io::Result<()> {
+        self.header.write_to(&mut self.output)
+    }
+
+    /// Write the table and resource data.
+    fn write_tables(&mut self) -> io::Result<()> {
+        for table in &self.tables {
+            table.write_to(&mut self.output)?;
+        }
+        for table in &self.tables {
+            for resource in table.resources() {
+                resource.write_to(&mut self.output)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Consume the writer and return the underlying Write instance.
+    fn into_inner(self) -> W {
+        self.output
     }
 }
 
@@ -36,109 +220,72 @@ impl Default for Strategy {
 ///
 /// ```rust
 /// use std::{io::Cursor, fs::File};
-/// use genie_drs::{DRSWriter, WriteStrategy};
+/// use genie_drs::{DRSWriter, InMemoryStrategy};
 /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
 /// let buf = Cursor::new(vec![]);
-/// let mut writer = DRSWriter::new(buf, WriteStrategy::InMemory)?;
+/// let mut writer = DRSWriter::new(buf, InMemoryStrategy::default())?;
 /// writer.add("bina", 50500, "JASC-PAL\r\n0100\r\n...".as_bytes())?;
 /// writer.add("slp", 2, &b"some bytes"[..])?;
 /// let buf = writer.flush()?;
 /// // → a Vec<u8> containing the DRS file
 /// # Ok(()) }
 /// ```
-pub struct DRSWriter<W>
+pub struct DRSWriter<W, S>
 where
     W: Write + Seek,
+    S: Strategy<W>,
 {
-    inner: W,
-    header: DRSHeader,
-    tables: Vec<DRSTable>,
-    resources: Vec<Vec<u8>>,
-    write_offset: u32,
-    strategy: Strategy,
+    inner: InnerDRSWriter<W>,
+    strategy: S,
 }
 
-impl<W> DRSWriter<W>
+impl<W, S> DRSWriter<W, S>
 where
     W: Write + Seek,
+    S: Strategy<W>,
 {
     /// Create a writer with the given strategy.
-    pub fn new(output: W, strategy: Strategy) -> Result<Self> {
-        let header = DRSHeader {
-            banner_msg: *b"Copyright (c) 1997 Ensemble Studios.\x1a\x00\x00\x00",
-            version: *b"1.00",
-            password: *b"tribe\x00\x00\x00\x00\x00\x00\x00",
-            num_resource_types: 0,
-            directory_size: 0,
-        };
+    pub fn new(output: W, strategy: S) -> io::Result<Self> {
+        let header = DRSHeader::default();
 
         let mut writer = Self {
-            inner: output,
-            header,
-            tables: vec![],
-            resources: if let Strategy::InMemory = strategy {
-                vec![]
-            } else {
-                Vec::with_capacity(0)
+            inner: InnerDRSWriter {
+                output,
+                header,
+                tables: vec![],
             },
-            write_offset: 0,
             strategy,
         };
 
-        writer.write_reserved()?;
+        writer.strategy.open(&mut writer.inner)?;
 
         Ok(writer)
     }
 
-    /// Write 0 bytes for reserved space at the top of the file.
-    fn write_reserved(&mut self) -> Result<()> {
-        if let Strategy::ReserveDirectory(tables, files) = self.strategy {
-            self.header.directory_size = 64 + 12 * (tables + files);
-            self.write_header()?;
-            let reserved = vec![0; self.header.directory_size as usize - 64];
-            self.inner.write_all(&reserved)?;
-            self.write_offset = self.header.directory_size;
-        }
-        Ok(())
-    }
-
-    /// Write the .drs archive header.
-    fn write_header(&mut self) -> Result<()> {
-        self.header.write_to(&mut self.inner)
-    }
-
-    /// Write the table and resource data.
-    fn write_tables(&mut self) -> Result<()> {
-        for table in &self.tables {
-            table.write_to(&mut self.inner)?;
-        }
-        for table in &self.tables {
-            for resource in table.resources() {
-                resource.write_to(&mut self.inner)?;
-            }
-        }
-        Ok(())
-    }
-
     /// Add a file to the archive.
     #[inline]
-    pub fn add(&mut self, t: impl Into<ResourceType>, id: u32, data: impl Read) -> Result<()> {
+    pub fn add(&mut self, t: impl Into<ResourceType>, id: u32, data: impl Read) -> io::Result<()> {
         self.add_inner(t.into(), id, data)
     }
 
-    fn add_inner(&mut self, t: ResourceType, id: u32, mut data: impl Read) -> Result<()> {
+    fn add_inner(&mut self, t: ResourceType, id: u32, data: impl Read) -> io::Result<()> {
         let res = DRSResource {
             id,
             offset: 0, // TBD
             size: 0,   // TBD
         };
 
-        let res = match self
+        let res = self.strategy.add_resource(&mut self.inner, t, res, data)?;
+
+        match self
+            .inner
             .tables
             .iter_mut()
             .find(|table| table.resource_type == t)
         {
-            Some(table) => table.add(res),
+            Some(table) => {
+                table.add(res);
+            }
             None => {
                 let mut table = DRSTable {
                     resource_type: t,
@@ -147,30 +294,7 @@ where
                     resources: vec![],
                 };
                 table.add(res);
-                self.tables.push(table);
-                self.tables
-                    .last_mut()
-                    .unwrap()
-                    .resources
-                    .last_mut()
-                    .unwrap()
-            }
-        };
-
-        match self.strategy {
-            Strategy::InMemory => {
-                let mut bytes = vec![];
-                data.read_to_end(&mut bytes)?;
-                assert!(bytes.len() < u32::max_value() as usize, "file too large");
-                res.size = bytes.len() as u32;
-                self.resources.push(bytes);
-            }
-            Strategy::ReserveDirectory(_, _) => {
-                let len = std::io::copy(&mut data, &mut self.inner)?;
-                assert!(len < u32::max_value() as u64, "file too large");
-                res.offset = self.write_offset;
-                res.size = len as u32;
-                self.write_offset += res.size;
+                self.inner.tables.push(table);
             }
         }
 
@@ -178,42 +302,16 @@ where
     }
 
     /// Finish any writes that still need to happen and return the file handle.
-    pub fn flush(mut self) -> Result<W> {
+    pub fn flush(mut self) -> io::Result<W> {
         assert!(
-            self.tables.len() < u32::max_value() as usize,
+            self.inner.tables.len() < u32::max_value() as usize,
             "too many tables"
         );
-        self.header.num_resource_types = self.tables.len() as u32;
+        self.inner.header.num_resource_types = self.inner.tables.len() as u32;
 
-        match self.strategy {
-            Strategy::InMemory => {
-                assert!(
-                    self.resources.len() < u32::max_value() as usize,
-                    "too many resources"
-                );
-                self.header.directory_size = 64 + 12 * (self.tables.len() + self.resources.len()) as u32;
-                unimplemented!();
-            }
-            Strategy::ReserveDirectory(_, _) => {
-                // Update the resource type count
-                self.inner.seek(SeekFrom::Start(56))?;
-                self.inner.write_u32::<LE>(self.header.num_resource_types)?;
-                self.inner.seek(SeekFrom::Current(4))?;
+        self.strategy.close(&mut self.inner)?;
 
-                // Assign table offsets
-                let mut table_offset = 64 + 12 * (self.tables.len() as u32);
-                for table in self.tables.iter_mut() {
-                    table.offset = table_offset;
-                    table_offset += 12 * (table.len() as u32);
-                }
-
-                // Write out all the table data
-                self.write_tables()?;
-                self.inner.seek(SeekFrom::End(0))?;
-            }
-        }
-
-        Ok(self.inner)
+        Ok(self.inner.into_inner())
     }
 }
 
@@ -225,7 +323,7 @@ mod test {
     #[test]
     fn basic() {
         let f = File::create("/tmp/x.drs").unwrap();
-        let mut drs = DRSWriter::new(f, Strategy::ReserveDirectory(1, 1)).unwrap();
+        let mut drs = DRSWriter::new(f, ReserveDirectoryStrategy::new(1, 1)).unwrap();
         drs.add("txt", 1, "example test file".as_bytes()).unwrap();
         drs.flush().unwrap();
     }

--- a/crates/genie-drs/src/write.rs
+++ b/crates/genie-drs/src/write.rs
@@ -1,5 +1,5 @@
-use byteorder::{WriteBytesExt, LE};
 use crate::{DRSHeader, DRSResource, DRSTable, ResourceType};
+use byteorder::{WriteBytesExt, LE};
 use std::io::{Read, Result, Seek, SeekFrom, Write};
 
 /// Strategy to use when writing files to the archive.
@@ -118,7 +118,12 @@ where
                 };
                 table.add(res);
                 self.tables.push(table);
-                self.tables.last_mut().unwrap().resources.last_mut().unwrap()
+                self.tables
+                    .last_mut()
+                    .unwrap()
+                    .resources
+                    .last_mut()
+                    .unwrap()
             }
         };
 
@@ -176,7 +181,8 @@ mod test {
     fn basic() {
         let f = File::create("/tmp/x.drs").unwrap();
         let mut drs = DRSWriter::new(f, Strategy::ReserveDirectory(1, 1)).unwrap();
-        drs.add(*b" txt", 1, "example test file".as_bytes()).unwrap();
+        drs.add(*b" txt", 1, "example test file".as_bytes())
+            .unwrap();
         drs.flush().unwrap();
     }
 }

--- a/examples/extractdrs.rs
+++ b/examples/extractdrs.rs
@@ -163,7 +163,7 @@ fn add(args: Add) -> CliResult {
     for t in drs_read.tables() {
         for r in t.resources() {
             let b = drs_read.get_resource_reader(&mut input, t.resource_type, r.id)?;
-            drs_write.add(t.resource_type, r.id, b.as_ref())?;
+            drs_write.add(t.resource_type, r.id, b)?;
         }
     }
 

--- a/examples/extractdrs.rs
+++ b/examples/extractdrs.rs
@@ -4,7 +4,7 @@ use std::{
     path::PathBuf,
     collections::HashSet,
 };
-use genie_drs::{DRSReader, DRSWriter, WriteStrategy};
+use genie_drs::{DRSReader, DRSWriter, ReserveDirectoryStrategy};
 use quicli::prelude::*;
 use structopt::StructOpt;
 
@@ -158,7 +158,7 @@ fn add(args: Add) -> CliResult {
 
     let output = File::create(&temp_out)?;
     let mut drs_write = DRSWriter::new(output,
-        WriteStrategy::ReserveDirectory(tables + new_tables, files + new_files))?;
+        ReserveDirectoryStrategy::new(tables + new_tables, files + new_files))?;
 
     for t in drs_read.tables() {
         for r in t.resources() {

--- a/examples/extractdrs.rs
+++ b/examples/extractdrs.rs
@@ -162,7 +162,7 @@ fn add(args: Add) -> CliResult {
 
     for t in drs_read.tables() {
         for r in t.resources() {
-            let b = drs_read.read_resource(&mut input, t.resource_type, r.id)?;
+            let b = drs_read.get_resource_reader(&mut input, t.resource_type, r.id)?;
             drs_write.add(t.resource_type, r.id, b.as_ref())?;
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,9 @@
 //!
 //! Support for palette files is implemented by [chariot_palette](https://github.com/ChariotEngine/Palette/).
 //! chariot_palette only supports _reading_ palette files at the moment.
+
+#![warn(rust_2018_idioms)]
+
 pub use genie_cpx as cpx;
 pub use genie_drs as drs;
 pub use genie_hki as hki;
@@ -62,7 +65,7 @@ pub use genie_scx as scx;
 pub use chariot_palette as pal;
 
 pub use genie_cpx::Campaign;
-pub use genie_drs::DRSReader;
+pub use genie_drs::{DRSReader, DRSWriter};
 pub use genie_hki::HotkeyInfo;
 pub use genie_lang::LangFile;
 pub use genie_scx::Scenario;


### PR DESCRIPTION
This adds a `DRSWriter` API that can be used to create DRS archives. It can progressively write archives without keeping all contained files in memory, by reserving space for the header and filling it in after the fact.

I also want to add an "in-memory" mode that _does_ keep everything in memory and doesn't have to seek back to the start of the file, but that is still incomplete.