### PR TITLE
drs: find resources faster using binary search

### DIFF
--- a/crates/genie-drs/Cargo.toml
+++ b/crates/genie-drs/Cargo.toml
@@ -11,3 +11,4 @@ readme = "README.md"
 
 [dependencies]
 byteorder = "^1.3.1"
+sorted-vec = "^0.3.0"

--- a/crates/genie-drs/src/write.rs
+++ b/crates/genie-drs/src/write.rs
@@ -301,12 +301,7 @@ where
                 table.add(res);
             }
             None => {
-                let mut table = DRSTable {
-                    resource_type: t,
-                    offset: 0, // TBD
-                    num_resources: 0,
-                    resources: vec![],
-                };
+                let mut table = DRSTable::new(t, 0, 0);
                 table.add(res);
                 self.inner.tables.push(table);
             }


### PR DESCRIPTION
Using a sorted vector to index into the `resources` vector. The order of the resources vector needs to be maintained for the in-memory writer, if that is refactored we can do an ordered insert into the resources vector instead and don't have to keep both in sync.