### PR TITLE
use thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ jascpal = { version = "0.1.0", path = "crates/jascpal" }
 
 [dev-dependencies]
 structopt = "^0.3.11"
+anyhow = "1.0.27"
 
 [workspace]
 members = [

--- a/crates/genie-cpx/Cargo.toml
+++ b/crates/genie-cpx/Cargo.toml
@@ -14,3 +14,7 @@ byteorder = "^1.3.1"
 chardet = "^0.2.4"
 encoding_rs = "^0.8.17"
 genie-scx = { version = "2.0.0", path = "../genie-scx" }
+thiserror = "1.0.13"
+
+[dev-dependencies]
+anyhow = "1.0.27"

--- a/crates/genie-cpx/src/lib.rs
+++ b/crates/genie-cpx/src/lib.rs
@@ -104,7 +104,7 @@ mod tests {
     use std::io::Cursor;
 
     #[test]
-    fn rebuild_cpx() -> Result<(), Box<dyn std::error::Error>> {
+    fn rebuild_cpx() -> anyhow::Result<()> {
         let instream = File::open("./test/campaigns/Armies at War A Combat Showcase.cpn")?;
         let mut outstream = vec![];
         let mut incpx = Campaign::from(instream)?;
@@ -118,7 +118,7 @@ mod tests {
     }
 
     #[test]
-    fn rebuild_cpn_de() -> Result<(), Box<dyn std::error::Error>> {
+    fn rebuild_cpn_de() -> anyhow::Result<()> {
         let instream = File::open("./test/campaigns/10 The First Punic War.aoecpn")?;
         let mut outstream = vec![];
         let mut incpx = Campaign::from(instream)?;

--- a/crates/genie-cpx/src/read.rs
+++ b/crates/genie-cpx/src/read.rs
@@ -6,47 +6,24 @@ use genie_scx::{self as scx, Scenario};
 use std::io::{self, Cursor, Read, Seek, SeekFrom};
 
 /// Type for errrors that could occur while reading/parsing a campaign file.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ReadCampaignError {
     /// A string could not be decoded, its encoding may be unknown or it may be binary nonsense.
+    #[error("invalid string")]
     DecodeStringError,
     /// An I/O error occurred.
-    IoError(io::Error),
+    #[error("{}", .0)]
+    IoError(#[from] io::Error),
     /// The campaign file or a scenario inside it is missing a user-facing name value.
+    #[error("campaign or scenario must have a name")]
     MissingNameError,
     /// The requested scenario file does not exist in this campaign file.
+    #[error("scenario not fonud in campaign")]
     NotFoundError,
     /// A scenario file could not be parsed.
-    ParseSCXError(scx::Error),
+    #[error("{}", .0)]
+    ParseSCXError(#[from] scx::Error),
 }
-
-impl From<io::Error> for ReadCampaignError {
-    fn from(err: io::Error) -> ReadCampaignError {
-        ReadCampaignError::IoError(err)
-    }
-}
-
-impl From<scx::Error> for ReadCampaignError {
-    fn from(err: scx::Error) -> ReadCampaignError {
-        ReadCampaignError::ParseSCXError(err)
-    }
-}
-
-impl std::fmt::Display for ReadCampaignError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ReadCampaignError::DecodeStringError => write!(f, "invalid string"),
-            ReadCampaignError::IoError(err) => write!(f, "{}", err),
-            ReadCampaignError::MissingNameError => {
-                write!(f, "campaign or scenario must have a name")
-            }
-            ReadCampaignError::NotFoundError => write!(f, "scenario not found in campaign"),
-            ReadCampaignError::ParseSCXError(err) => write!(f, "{}", err),
-        }
-    }
-}
-
-impl std::error::Error for ReadCampaignError {}
 
 type Result<T> = std::result::Result<T, ReadCampaignError>;
 
@@ -276,14 +253,15 @@ where
 mod tests {
     use super::*;
     use crate::{AOE1_DE, AOE_AOK};
+    use anyhow::Context;
     use std::fs::File;
 
     /// Try to parse a file with an encoding that is not compatible with UTF-8.
     /// Source: http://aok.heavengames.com/blacksmith/showfile.php?fileid=884
     #[test]
-    fn detect_encoding() {
-        let f = File::open("./test/campaigns/DER FALL VON SACSAHUAMAN - TEIL I.cpx").unwrap();
-        let cpx = Campaign::from(f).unwrap();
+    fn detect_encoding() -> anyhow::Result<()> {
+        let f = File::open("./test/campaigns/DER FALL VON SACSAHUAMAN - TEIL I.cpx")?;
+        let cpx = Campaign::from(f)?;
         assert_eq!(cpx.version(), AOE_AOK);
         assert_eq!(cpx.name(), "DER FALL VON SACSAHUAMÁN - TEIL I");
         assert_eq!(cpx.len(), 1);
@@ -292,13 +270,14 @@ mod tests {
         assert_eq!(names, vec!["Der Weg nach Sacsahuamán"]);
         let filenames: Vec<_> = cpx.entries().map(|e| &e.filename).collect();
         assert_eq!(filenames, vec!["Der Weg nach Sacsahuamán.scx"]);
+        Ok(())
     }
 
     /// Source: http://aoe.heavengames.com/dl-php/showfile.php?fileid=1678
     #[test]
-    fn aoe1_trial_cpn() {
-        let f = File::open("test/campaigns/Armies at War A Combat Showcase.cpn").unwrap();
-        let mut c = Campaign::from(f).expect("could not read meta");
+    fn aoe1_trial_cpn() -> anyhow::Result<()> {
+        let f = File::open("test/campaigns/Armies at War A Combat Showcase.cpn")?;
+        let mut c = Campaign::from(f).context("could not read meta")?;
 
         assert_eq!(c.version(), AOE_AOK);
         assert_eq!(c.name(), "Armies at War, A Combat Showcase");
@@ -308,15 +287,16 @@ mod tests {
         let filenames: Vec<_> = c.entries().map(|e| &e.filename).collect();
         assert_eq!(filenames, vec!["Bronze Age Art of War.scn"]);
 
-        c.by_index_raw(0).expect("could not read raw file");
+        c.by_index_raw(0).context("could not read raw file")?;
         c.by_name_raw("Bronze Age Art of War.scn")
-            .expect("could not read raw file");
+            .context("could not read raw file")?;
+        Ok(())
     }
 
     #[test]
-    fn aoe1_beta_cpn() {
-        let f = File::open("test/campaigns/Rise of Egypt Learning Campaign.cpn").unwrap();
-        let c = Campaign::from(f).expect("could not read meta");
+    fn aoe1_beta_cpn() -> anyhow::Result<()> {
+        let f = File::open("test/campaigns/Rise of Egypt Learning Campaign.cpn")?;
+        let c = Campaign::from(f).context("could not read meta")?;
 
         assert_eq!(c.version(), AOE_AOK);
         assert_eq!(c.name(), "Rise of Egypt Learning Campaign");
@@ -339,10 +319,11 @@ mod tests {
                 "Siege Battle.scn",
             ]
         );
+        Ok(())
     }
 
     #[test]
-    fn aoe_de() -> Result<()> {
+    fn aoe_de() -> anyhow::Result<()> {
         let f = File::open("test/campaigns/10 The First Punic War.aoecpn")?;
         let c = Campaign::from(f)?;
 

--- a/crates/genie-cpx/src/write.rs
+++ b/crates/genie-cpx/src/write.rs
@@ -4,33 +4,16 @@ use genie_scx::{Result as SCXResult, Scenario};
 use std::io::{self, Write};
 
 /// Type for errors that could occur during writing.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum WriteCampaignError {
     /// An I/O error occurred during writing.
-    IoError(io::Error),
+    #[error("{}", .0)]
+    IoError(#[from] io::Error),
     /// A scenario could not be found, either because the original campaign file was corrupt, or
     /// the scenario file exists but could not be parsed.
+    #[error("missing scenario data for index {}", .0)]
     NotFoundError(usize),
 }
-
-impl From<io::Error> for WriteCampaignError {
-    fn from(err: io::Error) -> WriteCampaignError {
-        WriteCampaignError::IoError(err)
-    }
-}
-
-impl std::fmt::Display for WriteCampaignError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            WriteCampaignError::IoError(err) => write!(f, "{}", err),
-            WriteCampaignError::NotFoundError(n) => {
-                write!(f, "missing scenario data for index {}", n)
-            }
-        }
-    }
-}
-
-impl std::error::Error for WriteCampaignError {}
 
 #[must_use]
 fn write_variable_str<W: Write>(output: &mut W, value: &str) -> io::Result<()> {

--- a/crates/genie-dat/Cargo.toml
+++ b/crates/genie-dat/Cargo.toml
@@ -15,3 +15,7 @@ encoding_rs = "^0.8.17"
 flate2 = { version = "^1.0.0", features = ["rust_backend"], default-features = false }
 genie-support = { version = "^0.0.0", path = "../genie-support" }
 jascpal = { version = "^0.1.0", path = "../jascpal" }
+thiserror = "1.0.13"
+
+[dev-dependencies]
+anyhow = "1.0.27"

--- a/crates/genie-dat/src/lib.rs
+++ b/crates/genie-dat/src/lib.rs
@@ -511,36 +511,40 @@ mod tests {
     };
 
     #[test]
-    fn aok() {
-        let mut f = File::open("fixtures/aok.dat").unwrap();
-        let dat = DatFile::read_from(&mut f).unwrap();
+    fn aok() -> anyhow::Result<()> {
+        let mut f = File::open("fixtures/aok.dat")?;
+        let dat = DatFile::read_from(&mut f)?;
         assert_eq!(dat.civilizations.len(), 14);
+        Ok(())
     }
 
     #[test]
-    fn aoc() {
-        let mut f = File::open("fixtures/aoc1.0c.dat").unwrap();
-        let dat = DatFile::read_from(&mut f).unwrap();
+    fn aoc() -> anyhow::Result<()> {
+        let mut f = File::open("fixtures/aoc1.0c.dat")?;
+        let dat = DatFile::read_from(&mut f)?;
         assert_eq!(dat.civilizations.len(), 19);
+        Ok(())
     }
 
     #[test]
-    fn non_7bit_ascii_tech_name() {
-        let mut f = File::open("fixtures/age-of-chivalry.dat").unwrap();
-        let dat = DatFile::read_from(&mut f).unwrap();
+    fn non_7bit_ascii_tech_name() -> anyhow::Result<()> {
+        let mut f = File::open("fixtures/age-of-chivalry.dat")?;
+        let dat = DatFile::read_from(&mut f)?;
         assert_eq!(dat.techs[859].name(), "Székely (enable)");
+        Ok(())
     }
 
     #[test]
-    fn hd_edition() {
-        let mut f = File::open("fixtures/hd.dat").unwrap();
-        let dat = DatFile::read_from(&mut f).unwrap();
+    fn hd_edition() -> anyhow::Result<()> {
+        let mut f = File::open("fixtures/hd.dat")?;
+        let dat = DatFile::read_from(&mut f)?;
         assert_eq!(dat.civilizations.len(), 32);
+        Ok(())
     }
 
     #[test]
     #[ignore]
-    fn reserialize() -> Result<()> {
+    fn reserialize() -> anyhow::Result<()> {
         let original = std::fs::read("fixtures/aoc1.0c.dat")?;
         let mut cursor = Cursor::new(&original);
         let dat = DatFile::read_from(&mut cursor)?;

--- a/crates/genie-dat/src/tech_tree.rs
+++ b/crates/genie-dat/src/tech_tree.rs
@@ -30,16 +30,9 @@ impl std::default::Default for TechTreeStatus {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, thiserror::Error)]
+#[error("invalid tech tree node status {} (must be 1-5)", .0)]
 pub struct ParseTechTreeStatusError(u8);
-
-impl std::fmt::Display for ParseTechTreeStatusError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "invalid tech tree node status {} (must be 1-5)", self.0)
-    }
-}
-
-impl std::error::Error for ParseTechTreeStatusError {}
 
 impl TryFrom<u8> for TechTreeStatus {
     type Error = ParseTechTreeStatusError;
@@ -90,16 +83,9 @@ impl std::default::Default for TechTreeType {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, thiserror::Error)]
+#[error("invalid tech tree node type {} (must be 0-7)", .0)]
 pub struct ParseTechTreeTypeError(i32);
-
-impl std::fmt::Display for ParseTechTreeTypeError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "invalid tech tree node type {} (must be 0-7)", self.0)
-    }
-}
-
-impl std::error::Error for ParseTechTreeTypeError {}
 
 impl TryFrom<i32> for TechTreeType {
     type Error = ParseTechTreeTypeError;
@@ -177,20 +163,9 @@ enum TechTreeDependencyType {
     Research = 3,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, thiserror::Error)]
+#[error("invalid tech tree dependency type {} (must be 0-3)", .0)]
 pub struct ParseTechTreeDependencyTypeError(i32);
-
-impl std::fmt::Display for ParseTechTreeDependencyTypeError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "invalid tech tree dependency type {} (must be 0-3)",
-            self.0
-        )
-    }
-}
-
-impl std::error::Error for ParseTechTreeDependencyTypeError {}
 
 impl TryFrom<i32> for TechTreeDependencyType {
     type Error = ParseTechTreeDependencyTypeError;

--- a/crates/genie-drs/Cargo.toml
+++ b/crates/genie-drs/Cargo.toml
@@ -13,3 +13,7 @@ exclude = ["*.drs"]
 [dependencies]
 byteorder = "^1.3.1"
 sorted-vec = "^0.3.0"
+thiserror = "1.0.13"
+
+[dev-dependencies]
+anyhow = "1.0.27"

--- a/crates/genie-drs/src/lib.rs
+++ b/crates/genie-drs/src/lib.rs
@@ -100,16 +100,9 @@ impl ToString for ResourceType {
 ///
 /// This may be caused by:
 ///   - The input string not being 4 characters long
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
+#[error("invalid resource type, must be 4 characters")]
 pub struct ParseResourceTypeError;
-
-impl std::fmt::Display for ParseResourceTypeError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "invalid resource type, must be 4 characters")
-    }
-}
-
-impl std::error::Error for ParseResourceTypeError {}
 
 impl core::str::FromStr for ResourceType {
     type Err = ParseResourceTypeError;
@@ -374,7 +367,7 @@ mod tests {
     use std::fs::File;
 
     #[test]
-    fn it_works() -> Result<(), Box<dyn std::error::Error>> {
+    fn it_works() -> anyhow::Result<()> {
         let mut file = File::open("test.drs")?;
         let drs = DRSReader::new(&mut file)?;
         let mut expected = vec![

--- a/crates/genie-drs/src/write.rs
+++ b/crates/genie-drs/src/write.rs
@@ -342,7 +342,7 @@ mod test {
     static ONE_FILE: &[u8] = b"Copyright (c) 1997 Ensemble Studios.\x1a\x00\x00\x001.00tribe\x00\x00\x00\x00\x00\x00\x00\x01\x00\x00\x00\x58\x00\x00\x00 txt\x4C\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x58\x00\x00\x00\x11\x00\x00\x00example test file";
 
     #[test]
-    fn one_file_reserve() -> Result<(), Box<dyn std::error::Error>> {
+    fn one_file_reserve() -> anyhow::Result<()> {
         let output = Cursor::new(vec![]);
         let mut drs = DRSWriter::new(output, ReserveDirectoryStrategy::new(1, 1))?;
         drs.add("txt", 1, "example test file".as_bytes())?;
@@ -352,7 +352,7 @@ mod test {
     }
 
     #[test]
-    fn one_file_memory() -> Result<(), Box<dyn std::error::Error>> {
+    fn one_file_memory() -> anyhow::Result<()> {
         let output = Cursor::new(vec![]);
         let mut drs = DRSWriter::new(output, InMemoryStrategy::default())?;
         drs.add("txt", 1, "example test file".as_bytes())?;

--- a/crates/genie-hki/Cargo.toml
+++ b/crates/genie-hki/Cargo.toml
@@ -13,3 +13,7 @@ exclude = ["test/files"]
 byteorder = "^1.3.1"
 flate2 = "^1.0.0"
 genie-lang = { version = "^0.2.0", path = "../genie-lang" }
+thiserror = "1.0.13"
+
+[dev-dependencies]
+anyhow = "1.0.27"

--- a/crates/genie-lang/Cargo.toml
+++ b/crates/genie-lang/Cargo.toml
@@ -15,3 +15,7 @@ encoding_rs = "^0.8.17"
 encoding_rs_io = "^0.1.5"
 genie-support = { version = "0.0.0", path = "../genie-support" }
 pelite = { version = "^0.8.0", default-features = false, features = ["mmap"] }
+thiserror = "1.0.13"
+
+[dev-dependencies]
+anyhow = "1.0.27"

--- a/crates/genie-rec/Cargo.toml
+++ b/crates/genie-rec/Cargo.toml
@@ -12,6 +12,7 @@ flate2 = { version = "^1.0.0", features = ["rust_backend"], default-features = f
 genie-dat = { version = "0.1.0", path = "../genie-dat" }
 genie-scx = { version = "2.0.0", path = "../genie-scx" }
 genie-support = { version = "0.0.0", path = "../genie-support", features = ["strings"] }
+thiserror = "1.0.13"
 
 [dev-dependencies]
 anyhow = "1.0.27"

--- a/crates/genie-rec/src/lib.rs
+++ b/crates/genie-rec/src/lib.rs
@@ -111,22 +111,12 @@ impl GameVersion {
 }
 
 /// Errors that may occur while reading a recorded game file.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
-    IoError(io::Error),
-    DecodeStringError(genie_support::DecodeStringError),
-}
-
-impl From<io::Error> for Error {
-    fn from(err: io::Error) -> Self {
-        Self::IoError(err)
-    }
-}
-
-impl From<genie_support::DecodeStringError> for Error {
-    fn from(err: genie_support::DecodeStringError) -> Self {
-        Self::DecodeStringError(err)
-    }
+    #[error(transparent)]
+    IoError(#[from] io::Error),
+    #[error(transparent)]
+    DecodeStringError(#[from] genie_support::DecodeStringError),
 }
 
 impl From<genie_support::ReadStringError> for Error {
@@ -137,17 +127,6 @@ impl From<genie_support::ReadStringError> for Error {
         }
     }
 }
-
-impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::IoError(err) => write!(f, "{}", err),
-            Self::DecodeStringError(err) => write!(f, "{}", err),
-        }
-    }
-}
-
-impl std::error::Error for Error {}
 
 /// Result type alias with `genie_rec::Error` as the error type.
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/genie-rec/src/unit_type.rs
+++ b/crates/genie-rec/src/unit_type.rs
@@ -5,7 +5,7 @@ pub use genie_dat::AttributeCost;
 pub use genie_support::{StringKey, UnitTypeID};
 use std::cmp;
 use std::convert::{TryFrom, TryInto};
-use std::fmt;
+
 use std::io::{Read, Write};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/genie-rec/src/unit_type.rs
+++ b/crates/genie-rec/src/unit_type.rs
@@ -76,16 +76,9 @@ impl cmp::PartialOrd for UnitBaseClass {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, thiserror::Error)]
+#[error("unknown unit base class: {}", .0)]
 pub struct ParseUnitBaseClassError(u8);
-
-impl fmt::Display for ParseUnitBaseClassError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "unknown unit base class: {}", self.0)
-    }
-}
-
-impl std::error::Error for ParseUnitBaseClassError {}
 
 impl TryFrom<u8> for UnitBaseClass {
     type Error = ParseUnitBaseClassError;

--- a/crates/genie-scx/Cargo.toml
+++ b/crates/genie-scx/Cargo.toml
@@ -15,3 +15,7 @@ flate2 = "^1.0.0"
 genie-support = { version = "^0.0.0", path = "../genie-support", features = ["strings"] }
 nohash-hasher = "^0.2.0"
 rgb = "^0.8.13"
+thiserror = "1.0.13"
+
+[dev-dependencies]
+anyhow = "1.0.27"

--- a/crates/genie-scx/src/ai.rs
+++ b/crates/genie-scx/src/ai.rs
@@ -39,16 +39,9 @@ pub enum AIErrorCode {
 }
 
 /// Found an AI error code that isn't defined.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
+#[error("Unknown AI error code {}", .0)]
 pub struct ParseAIErrorCodeError(u32);
-
-impl std::fmt::Display for ParseAIErrorCodeError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "Unknown AI error code {}", self.0)
-    }
-}
-
-impl std::error::Error for ParseAIErrorCodeError {}
 
 impl TryFrom<u32> for AIErrorCode {
     type Error = ParseAIErrorCodeError;

--- a/crates/genie-scx/src/convert/mod.rs
+++ b/crates/genie-scx/src/convert/mod.rs
@@ -10,21 +10,12 @@ pub use aoc_to_wk::AoCToWK;
 pub use hd_to_wk::HDToWK;
 
 /// Error indicating scenario conversion failure.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ConvertError {
     /// The input scenario version is not supported by the converter.
+    #[error("invalid version")]
     InvalidVersion,
 }
-
-impl std::fmt::Display for ConvertError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ConvertError::InvalidVersion => write!(f, "invalid version"),
-        }
-    }
-}
-
-impl std::error::Error for ConvertError {}
 
 /// Convert an AoC or HD Edition scenario file to a WololoKingdoms one.
 ///

--- a/crates/genie-scx/src/lib.rs
+++ b/crates/genie-scx/src/lib.rs
@@ -36,49 +36,58 @@ pub use types::*;
 
 /// Error type for SCX methods, containing all types of errors that may occur while reading or
 /// writing scenario files.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum Error {
     /// The scenario that's attempted to be read does not contain a file name.
+    #[error("must have a file name")]
     MissingFileNameError,
     /// Attempted to read a scenario with an unsupported format version identifier.
+    #[error("unsupported format version {:?}", .0)]
     UnsupportedFormatVersionError(SCXVersion),
     /// Attempted to write a scenario with disabled technologies, to a version that doesn't support
     /// this many disabled technologies.
+    #[error("too many disabled techs: got {}, but requested version supports up to 20", .0)]
     TooManyDisabledTechsError(i32),
     /// Attempted to write a scenario with disabled technologies, to a version that doesn't support
     /// disabling technologies.
+    #[error("requested version does not support disabling techs")]
     CannotDisableTechsError,
     /// Attempted to write a scenario with disabled units, to a version that doesn't support
     /// disabling units.
+    #[error("requested version does not support disabling units")]
     CannotDisableUnitsError,
     /// Attempted to write a scenario with disabled buildings, to a version that doesn't support
     /// this many disabled buildings.
+    #[error("too many disabled buildings: got {}, but requested version supports up to {}", .0, .1)]
     TooManyDisabledBuildingsError(i32, i32),
     /// Attempted to write a scenario with disabled buildings, to a version that doesn't support
     /// disabling buildings.
+    #[error("requested version does not support disabling buildings")]
     CannotDisableBuildingsError,
     /// Failed to decode a string from the scenario file, probably because of a wrong encoding.
-    DecodeStringError(DecodeStringError),
+    #[error(transparent)]
+    DecodeStringError(#[from] DecodeStringError),
     /// Failed to encode a string into the scenario file, probably because of a wrong encoding.
-    EncodeStringError(EncodeStringError),
+    #[error(transparent)]
+    EncodeStringError(#[from] EncodeStringError),
     /// The given ID is not a known diplomatic stance.
-    ParseDiplomaticStanceError(ParseDiplomaticStanceError),
+    #[error(transparent)]
+    ParseDiplomaticStanceError(#[from] ParseDiplomaticStanceError),
     /// The given ID is not a known data set.
-    ParseDataSetError(ParseDataSetError),
+    #[error(transparent)]
+    ParseDataSetError(#[from] ParseDataSetError),
     /// The given ID is not a known HD Edition DLC.
-    ParseDLCPackageError(ParseDLCPackageError),
+    #[error(transparent)]
+    ParseDLCPackageError(#[from] ParseDLCPackageError),
     /// The given ID is not a known starting age in AoE1 or AoE2.
-    ParseStartingAgeError(ParseStartingAgeError),
+    #[error(transparent)]
+    ParseStartingAgeError(#[from] ParseStartingAgeError),
     /// The given ID is not a known error code.
-    ParseAIErrorCodeError(ParseAIErrorCodeError),
+    #[error(transparent)]
+    ParseAIErrorCodeError(#[from] ParseAIErrorCodeError),
     /// An error occurred while reading or writing.
-    IoError(io::Error),
-}
-
-impl From<io::Error> for Error {
-    fn from(err: io::Error) -> Error {
-        Error::IoError(err)
-    }
+    #[error(transparent)]
+    IoError(#[from] io::Error),
 }
 
 impl From<ReadStringError> for Error {
@@ -98,62 +107,6 @@ impl From<WriteStringError> for Error {
         }
     }
 }
-
-macro_rules! error_impl_from {
-    ($from:ident) => {
-        impl From<$from> for Error {
-            fn from(err: $from) -> Error {
-                Error::$from(err)
-            }
-        }
-    };
-}
-
-error_impl_from!(ParseDiplomaticStanceError);
-error_impl_from!(ParseDataSetError);
-error_impl_from!(ParseDLCPackageError);
-error_impl_from!(ParseStartingAgeError);
-error_impl_from!(ParseAIErrorCodeError);
-
-impl std::fmt::Display for Error {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Error::MissingFileNameError => write!(f, "must have a file name"),
-            Error::UnsupportedFormatVersionError(version) => {
-                write!(f, "unsupported format version {:?}", version)
-            }
-            Error::TooManyDisabledTechsError(n) => write!(
-                f,
-                "too many disabled techs: got {}, but requested version supports up to 20",
-                n
-            ),
-            Error::TooManyDisabledBuildingsError(n, max) => write!(
-                f,
-                "too many disabled buildings: got {}, but requested version supports up to {}",
-                n, max
-            ),
-            Error::CannotDisableTechsError => {
-                write!(f, "requested version does not support disabling techs")
-            }
-            Error::CannotDisableUnitsError => {
-                write!(f, "requested version does not support disabling units")
-            }
-            Error::CannotDisableBuildingsError => {
-                write!(f, "requested version does not support disabling buildings")
-            }
-            Error::IoError(err) => write!(f, "{}", err),
-            Error::DecodeStringError(err) => write!(f, "{}", err),
-            Error::EncodeStringError(err) => write!(f, "{}", err),
-            Error::ParseDiplomaticStanceError(err) => write!(f, "{}", err),
-            Error::ParseDataSetError(err) => write!(f, "{}", err),
-            Error::ParseDLCPackageError(err) => write!(f, "{}", err),
-            Error::ParseStartingAgeError(err) => write!(f, "{}", err),
-            Error::ParseAIErrorCodeError(err) => write!(f, "{}", err),
-        }
-    }
-}
-
-impl std::error::Error for Error {}
 
 /// Result type for SCX methods.
 pub type Result<T> = std::result::Result<T, Error>;

--- a/crates/genie-scx/src/types.rs
+++ b/crates/genie-scx/src/types.rs
@@ -7,16 +7,9 @@ use std::convert::TryFrom;
 pub type SCXVersion = [u8; 4];
 
 /// Could not parse a diplomatic stance because given number is an unknown stance ID.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, thiserror::Error)]
+#[error("invalid diplomatic stance {} (must be 0/1/3)", .0)]
 pub struct ParseDiplomaticStanceError(i32);
-
-impl std::fmt::Display for ParseDiplomaticStanceError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "invalid diplomatic stance {} (must be 0/1/3)", self.0)
-    }
-}
-
-impl std::error::Error for ParseDiplomaticStanceError {}
 
 /// A player's diplomatic stance toward another player.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -53,16 +46,9 @@ impl From<DiplomaticStance> for i32 {
 }
 
 /// Could not parse a data set because given number is an unknown data set ID.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, thiserror::Error)]
+#[error("invalid data set {} (must be 0/1)", .0)]
 pub struct ParseDataSetError(i32);
-
-impl std::fmt::Display for ParseDataSetError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "invalid data set {} (must be 0/1)", self.0)
-    }
-}
-
-impl std::error::Error for ParseDataSetError {}
 
 /// The data set used by a scenario, HD Edition only.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -94,16 +80,9 @@ impl From<DataSet> for i32 {
 }
 
 /// Could not parse a DLC package identifier because given number is an unknown DLC ID.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, thiserror::Error)]
+#[error("unknown dlc package {}", .0)]
 pub struct ParseDLCPackageError(i32);
-
-impl std::fmt::Display for ParseDLCPackageError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "unknown dlc package {}", self.0)
-    }
-}
-
-impl std::error::Error for ParseDLCPackageError {}
 
 /// An HD Edition DLC identifier.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -150,25 +129,21 @@ impl From<DLCPackage> for i32 {
     }
 }
 
+fn expected_range(version: f32) -> &'static str {
+    if version < 1.25 {
+        "-1-4"
+    } else {
+        "-1-6"
+    }
+}
+
 /// Could not parse a starting age because given number refers to an unknown age.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, thiserror::Error)]
+#[error("invalid starting age {} (must be {})", .found, expected_range(*.version))]
 pub struct ParseStartingAgeError {
     version: f32,
     found: i32,
 }
-
-impl std::fmt::Display for ParseStartingAgeError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let expected = if self.version < 1.25 { "-1-4" } else { "-1-6" };
-        write!(
-            f,
-            "invalid starting age {} (must be {})",
-            self.found, expected
-        )
-    }
-}
-
-impl std::error::Error for ParseStartingAgeError {}
 
 /// The starting age.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]

--- a/crates/genie-support/Cargo.toml
+++ b/crates/genie-support/Cargo.toml
@@ -11,6 +11,10 @@ repository = "https://github.com/SiegeEngineers/genie-rs"
 [dependencies]
 byteorder = "^1.3.1"
 encoding_rs = { version = "0.8", optional = true }
+thiserror = "1.0.13"
 
 [features]
 strings = ["encoding_rs"]
+
+[dev-dependencies]
+anyhow = "1.0.27"

--- a/crates/genie-support/src/ids.rs
+++ b/crates/genie-support/src/ids.rs
@@ -239,16 +239,9 @@ impl From<String> for StringKey {
 ///
 /// When converting to a string, this does not happen, as numeric keys will be converted to
 /// strings.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, thiserror::Error)]
+#[error("could not convert StringKey to the wanted integer size")]
 pub struct TryFromStringKeyError;
-
-impl fmt::Display for TryFromStringKeyError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "could not convert StringKey to the wanted integer size")
-    }
-}
-
-impl std::error::Error for TryFromStringKeyError {}
 
 // Implement TryFrom<&StringKey> conversions for a bunch of stuff
 macro_rules! try_from_string_key {

--- a/crates/genie-support/src/strings.rs
+++ b/crates/genie-support/src/strings.rs
@@ -6,57 +6,37 @@ use std::io::{self, Read, Write};
 ///
 /// This means that the scenario file contained a string that could not be decoded using the
 /// WINDOWS-1252 code page. In the future, genie-scx will support other encodings.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, thiserror::Error)]
+#[error("could not decode string as WINDOWS-1252")]
 pub struct DecodeStringError;
-
-impl std::fmt::Display for DecodeStringError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "could not decode string as WINDOWS-1252")
-    }
-}
-
-impl std::error::Error for DecodeStringError {}
 
 /// Failed to encode a string as WINDOWS-1252.
 ///
 /// This means that a string could not be encoded using the WINDOWS-1252 code page. In the future, genie-scx will support other encodings.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, thiserror::Error)]
+#[error("could not encode string as WINDOWS-1252")]
 pub struct EncodeStringError;
 
-impl std::fmt::Display for EncodeStringError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "could not encode string as WINDOWS-1252")
-    }
-}
-
-impl std::error::Error for EncodeStringError {}
-
 /// Failed to read a string.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ReadStringError {
     /// Failed to read a string because the bytes could not be decoded.
-    DecodeStringError(DecodeStringError),
+    #[error(transparent)]
+    DecodeStringError(#[from] DecodeStringError),
     /// Failed to read a string because the underlying I/O failed.
-    IoError(io::Error),
-}
-impl From<io::Error> for ReadStringError {
-    fn from(err: io::Error) -> ReadStringError {
-        ReadStringError::IoError(err)
-    }
+    #[error(transparent)]
+    IoError(#[from] io::Error),
 }
 
 /// Failed to write a string.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum WriteStringError {
     /// Failed to read a string because it could not be encoded.
-    EncodeStringError(EncodeStringError),
+    #[error(transparent)]
+    EncodeStringError(#[from] EncodeStringError),
     /// Failed to write a string because the underlying I/O failed.
-    IoError(std::io::Error),
-}
-impl From<io::Error> for WriteStringError {
-    fn from(err: io::Error) -> WriteStringError {
-        WriteStringError::IoError(err)
-    }
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
 }
 
 pub fn read_str<R: Read>(input: &mut R, length: usize) -> Result<Option<String>, ReadStringError> {

--- a/crates/jascpal/Cargo.toml
+++ b/crates/jascpal/Cargo.toml
@@ -11,3 +11,7 @@ repository = "https://github.com/SiegeEngineers/genie-rs"
 [dependencies]
 nom = { version = "^5.0.0", default-features = false, features = ["std"] }
 rgb = "^0.8.13"
+thiserror = "1.0.13"
+
+[dev-dependencies]
+anyhow = "1.0.27"

--- a/crates/jascpal/src/lib.rs
+++ b/crates/jascpal/src/lib.rs
@@ -153,30 +153,14 @@ fn parse(input: &[u8]) -> IResult<&[u8], Vec<Color>> {
 }
 
 /// An error occurred during reading.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum ReadPaletteError {
     /// An I/O error occurred.
-    IoError(std::io::Error),
+    #[error(transparent)]
+    IoError(#[from] std::io::Error),
     /// The palette could not be parsed.
+    #[error("parse error")]
     ParseError,
-}
-
-impl fmt::Display for ReadPaletteError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        use ReadPaletteError::*;
-        match self {
-            IoError(err) => write!(f, "{}", err),
-            ParseError => write!(f, "parse error"),
-        }
-    }
-}
-
-impl std::error::Error for ReadPaletteError {}
-
-impl From<std::io::Error> for ReadPaletteError {
-    fn from(err: std::io::Error) -> Self {
-        ReadPaletteError::IoError(err)
-    }
 }
 
 /// A Palette.

--- a/crates/jascpal/src/lib.rs
+++ b/crates/jascpal/src/lib.rs
@@ -43,7 +43,7 @@ use nom::multi::many1;
 use nom::IResult;
 use rgb::RGB;
 use std::convert::{TryFrom, TryInto};
-use std::fmt;
+
 use std::io::{Read, Write};
 use std::num::TryFromIntError;
 use std::str::{self, FromStr};

--- a/examples/convertscx.rs
+++ b/examples/convertscx.rs
@@ -3,8 +3,6 @@ use genie::Scenario;
 use std::{fs::File, path::PathBuf};
 use structopt::StructOpt;
 
-type CliResult = Result<(), Box<dyn std::error::Error>>;
-
 /// Convert Age of Empires scenario files between versions.
 #[derive(Debug, StructOpt)]
 struct Cli {
@@ -21,7 +19,7 @@ struct Cli {
     version: Option<String>,
 }
 
-fn main() -> CliResult {
+fn main() -> anyhow::Result<()> {
     let Cli {
         input,
         output,

--- a/examples/displayaochotkeys.rs
+++ b/examples/displayaochotkeys.rs
@@ -8,7 +8,6 @@
 
 use genie::hki::{self, HotkeyInfo};
 use genie::lang::LangFileType;
-use std::error::Error;
 use std::fs::File;
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -33,7 +32,7 @@ struct DisplayLang {
 }
 
 /// Displays the hotkeys from a hotkey file and language file given to `stdout`.
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> anyhow::Result<()> {
     let cli_input = DisplayLang::from_args();
 
     let mut f_lang = File::open(&cli_input.lang_file_name)?;

--- a/examples/displaycivs.rs
+++ b/examples/displaycivs.rs
@@ -1,7 +1,8 @@
 //! Displays civilizations from a specified dat file.
 
 use genie::DatFile;
-use std::{error::Error, fs::File, path::PathBuf};
+use std::fs::File;
+use std::path::PathBuf;
 use structopt::StructOpt;
 
 /// Display civilizations from a specified dat file.
@@ -13,7 +14,7 @@ struct DisplayCivs {
 }
 
 /// Executes the CLI.
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> anyhow::Result<()> {
     let cli_input = DisplayCivs::from_args();
     let mut f = File::open(&cli_input.file_name)?;
     let dat = DatFile::read_from(&mut f)?;

--- a/examples/displayhotkey.rs
+++ b/examples/displayhotkey.rs
@@ -1,7 +1,6 @@
 //! Displays a hotkey to `stdout`.
 
 use genie::hki::HotkeyInfo;
-use std::error::Error;
 use std::fs::File;
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -30,7 +29,7 @@ struct DisplayHotkey {
 }
 
 /// Executes the CLI.
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> anyhow::Result<()> {
     let cli_input = DisplayHotkey::from_args();
     let mut f = File::open(&cli_input.file_name)?;
     let info = HotkeyInfo::from(&mut f)?;

--- a/examples/displaylang.rs
+++ b/examples/displaylang.rs
@@ -1,7 +1,6 @@
 //! Displays the key value pairs in a language file.
 
 use genie::lang::LangFileType;
-use std::error::Error;
 use std::fs::File;
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -22,7 +21,7 @@ struct DisplayLang {
 }
 
 /// Prints the key value pairs of an input language file to `stdout`.
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> anyhow::Result<()> {
     let cli_input = DisplayLang::from_args();
     let mut f = File::open(&cli_input.file_name)?;
     let lang_file = cli_input.file_type.read_from(&mut f)?;

--- a/examples/extractdrs.rs
+++ b/examples/extractdrs.rs
@@ -1,13 +1,9 @@
 use genie_drs::{DRSReader, DRSWriter, ReserveDirectoryStrategy};
-use std::{
-    collections::HashSet,
-    fs::{create_dir_all, File},
-    io::{self, stdout, Write},
-    path::PathBuf,
-};
+use std::collections::HashSet;
+use std::fs::{create_dir_all, File};
+use std::io::{self, stdout, Write};
+use std::path::PathBuf;
 use structopt::StructOpt;
-
-type CliResult = Result<(), Box<dyn std::error::Error>>;
 
 #[derive(StructOpt)]
 struct Cli {
@@ -80,7 +76,7 @@ struct Add {
     file: Vec<PathBuf>,
 }
 
-fn list(args: List) -> CliResult {
+fn list(args: List) -> anyhow::Result<()> {
     let mut file = File::open(args.archive)?;
     let drs = DRSReader::new(&mut file)?;
 
@@ -93,7 +89,7 @@ fn list(args: List) -> CliResult {
     Ok(())
 }
 
-fn get(args: Get) -> CliResult {
+fn get(args: Get) -> anyhow::Result<()> {
     let mut file = File::open(args.archive)?;
     let drs = DRSReader::new(&mut file)?;
 
@@ -115,7 +111,7 @@ fn get(args: Get) -> CliResult {
     .into())
 }
 
-fn extract(args: Extract) -> CliResult {
+fn extract(args: Extract) -> anyhow::Result<()> {
     let mut file = File::open(args.archive)?;
     let drs = DRSReader::new(&mut file)?;
 
@@ -140,7 +136,7 @@ fn extract(args: Extract) -> CliResult {
     Ok(())
 }
 
-fn add(args: Add) -> CliResult {
+fn add(args: Add) -> anyhow::Result<()> {
     assert_eq!(
         args.file.len(),
         args.table.len(),
@@ -215,7 +211,7 @@ fn add(args: Add) -> CliResult {
     Ok(())
 }
 
-fn main() -> CliResult {
+fn main() -> anyhow::Result<()> {
     let args = Cli::from_args();
 
     match args.command {

--- a/examples/sethotkey.rs
+++ b/examples/sethotkey.rs
@@ -1,7 +1,6 @@
 //! Sets a hotkey in a hotkey file.
 
 use genie::hki::HotkeyInfo;
-use std::error::Error;
 use std::fs::File;
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -46,7 +45,7 @@ struct SetHotkey {
 }
 
 /// Executes the CLI.
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> anyhow::Result<()> {
     let cli_input = SetHotkey::from_args();
     let mut f = File::open(&cli_input.file_name)?;
     let info = HotkeyInfo::from(&mut f)?;

--- a/examples/wolololang.rs
+++ b/examples/wolololang.rs
@@ -5,7 +5,6 @@
 //! unspecified.
 
 use genie::lang::LangFileType::KeyValue;
-use std::error::Error;
 use std::fs::File;
 use std::path::PathBuf;
 use structopt::StructOpt;
@@ -27,7 +26,7 @@ struct WololoLang {
 
 /// Collects command line input and converts the specified key-value language
 /// file into an ini language file.
-fn main() -> Result<(), Box<dyn Error>> {
+fn main() -> anyhow::Result<()> {
     let cli_input = WololoLang::from_args();
     let mut f_in = File::open(&cli_input.path_in)?;
     let lang_file = KeyValue.read_from(&mut f_in)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@
 //! yet exposed in the public API.
 //!
 //! ```rust
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # fn main() -> anyhow::Result<()> {
 //! use genie::DatFile;
 //! let mut input = std::fs::File::open("./crates/genie-dat/fixtures/aok.dat")?;
 //!
@@ -33,7 +33,7 @@
 //! refer to terrains or units that do not exist in the different version.
 //!
 //! ```rust
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # fn main() -> anyhow::Result<()> {
 //! use genie::Scenario;
 //! use genie::scx::VersionBundle;
 //!


### PR DESCRIPTION
Remove manual `Error` implementations in favour of `thiserror`, which generates identical implementations with less code.