### PR TITLE
Idea: Disable missing docs?

### DIFF
--- a/crates/genie-cpx/src/lib.rs
+++ b/crates/genie-cpx/src/lib.rs
@@ -7,8 +7,8 @@
 #![deny(nonstandard_style)]
 #![deny(rust_2018_idioms)]
 #![deny(unsafe_code)]
-#![warn(missing_docs)]
 #![warn(unused)]
+#![allow(missing_docs)]
 
 use std::io::{Read, Seek, Write};
 

--- a/crates/genie-dat/src/lib.rs
+++ b/crates/genie-dat/src/lib.rs
@@ -7,8 +7,8 @@
 #![deny(nonstandard_style)]
 #![deny(rust_2018_idioms)]
 #![deny(unsafe_code)]
-#![warn(missing_docs)]
 #![warn(unused)]
+#![allow(missing_docs)]
 
 mod civ;
 mod color_table;

--- a/crates/genie-drs/src/lib.rs
+++ b/crates/genie-drs/src/lib.rs
@@ -26,8 +26,8 @@
 #![deny(nonstandard_style)]
 #![deny(rust_2018_idioms)]
 #![deny(unsafe_code)]
-#![warn(missing_docs)]
 #![warn(unused)]
+#![allow(missing_docs)]
 
 use byteorder::{ReadBytesExt, WriteBytesExt, LE};
 use sorted_vec::SortedVec;

--- a/crates/genie-hki/src/lib.rs
+++ b/crates/genie-hki/src/lib.rs
@@ -9,8 +9,8 @@
 #![deny(nonstandard_style)]
 #![deny(rust_2018_idioms)]
 #![deny(unsafe_code)]
-#![warn(missing_docs)]
 #![warn(unused)]
+#![allow(missing_docs)]
 
 use genie_lang::{LangFile, StringKey};
 

--- a/crates/genie-lang/src/lib.rs
+++ b/crates/genie-lang/src/lib.rs
@@ -105,8 +105,8 @@
 #![deny(nonstandard_style)]
 #![deny(rust_2018_idioms)]
 #![deny(unsafe_code)]
-#![warn(missing_docs)]
 #![warn(unused)]
+#![allow(missing_docs)]
 
 use byteorder::{ReadBytesExt, LE};
 use encoding_rs::{UTF_16LE, WINDOWS_1252};

--- a/crates/genie-scx/src/lib.rs
+++ b/crates/genie-scx/src/lib.rs
@@ -7,8 +7,8 @@
 #![deny(nonstandard_style)]
 #![deny(rust_2018_idioms)]
 #![deny(unsafe_code)]
-#![warn(missing_docs)]
 #![warn(unused)]
+#![allow(missing_docs)]
 
 mod ai;
 mod bitmap;

--- a/crates/genie-support/src/lib.rs
+++ b/crates/genie-support/src/lib.rs
@@ -4,8 +4,8 @@
 #![deny(nonstandard_style)]
 #![deny(rust_2018_idioms)]
 #![deny(unsafe_code)]
-#![warn(missing_docs)]
 #![warn(unused)]
+#![allow(missing_docs)]
 
 mod ids;
 mod macros;

--- a/crates/jascpal/src/lib.rs
+++ b/crates/jascpal/src/lib.rs
@@ -33,8 +33,8 @@
 #![deny(nonstandard_style)]
 #![deny(rust_2018_idioms)]
 #![deny(unsafe_code)]
-#![warn(missing_docs)]
 #![warn(unused)]
+#![allow(missing_docs)]
 
 use nom::bytes::complete::tag;
 use nom::character::complete::{digit1, one_of};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,8 +79,8 @@
 #![deny(nonstandard_style)]
 #![deny(rust_2018_idioms)]
 #![deny(unsafe_code)]
-#![warn(missing_docs)]
 #![warn(unused)]
+#![allow(missing_docs)]
 
 pub use genie_cpx as cpx;
 pub use genie_dat as dat;


### PR DESCRIPTION
Currently there are too many of them, which could allow
other more important warnings to be hidden in the noise.

Crates could opt-in to mark those as warning as required,
which will enable to fully cover all docs.