### PR TITLE
genie-rec: move to state based header reader, and define traits for elements

### DIFF
--- a/crates/genie-rec/src/ai.rs
+++ b/crates/genie-rec/src/ai.rs
@@ -1,5 +1,7 @@
 //! Read and write player AI state.
 
+use crate::element::{ReadableHeaderElement, WritableHeaderElement};
+use crate::reader::RecordingHeaderReader;
 use crate::unit::Waypoint;
 use crate::{ObjectID, PlayerID, Result};
 use byteorder::{ReadBytesExt, WriteBytesExt, LE};
@@ -13,8 +15,8 @@ pub struct MainAI {
     pub objects: Vec<ObjectID>,
 }
 
-impl MainAI {
-    pub fn read_from(mut input: impl Read) -> Result<Self> {
+impl ReadableHeaderElement for MainAI {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         let num_objects = input.read_u32::<LE>()?;
         let mut objects = vec![];
         for _ in 0..num_objects {
@@ -42,13 +44,14 @@ pub struct BuildItem {
     pub is_forward: bool,
 }
 
-impl BuildItem {
-    pub fn read_from(mut input: impl Read, version: f32) -> Result<Self> {
+impl ReadableHeaderElement for BuildItem {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         let mut item = BuildItem {
             name: input.read_u32_length_prefixed_str()?,
             type_id: input.read_u32::<LE>()?,
             ..Default::default()
         };
+
         let _a2 = input.read_u32::<LE>()?;
         item.game_id = input.read_u32::<LE>()?;
         let _v21 = input.read_u32::<LE>()?;
@@ -72,7 +75,7 @@ impl BuildItem {
         let _v12 = input.read_u32::<LE>()?;
         let _v29 = input.read_u32::<LE>()?;
         let _v31 = input.read_u8()?;
-        item.is_forward = if version > 10.87 {
+        item.is_forward = if input.version() > 10.87 {
             input.read_u32::<LE>()? != 0
         } else {
             false
@@ -93,15 +96,15 @@ pub struct BuildAI {
     pub queued_unit_count: u32,
 }
 
-impl BuildAI {
-    pub fn read_from(mut input: impl Read, version: f32) -> Result<Self> {
+impl ReadableHeaderElement for BuildAI {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         let mut ai = Self::default();
         let build_list_len = input.read_u32::<LE>()?;
         ai.build_list_name = input.read_u32_length_prefixed_str()?;
         ai.last_build_item_requested = input.read_u32_length_prefixed_str()?;
         ai.current_build_item_requested = input.read_u32_length_prefixed_str()?;
         ai.next_build_item_requested = input.read_u32_length_prefixed_str()?;
-        let _items_into_build_queue = if version > 11.02 {
+        let _items_into_build_queue = if input.version() > 11.02 {
             input.read_u32::<LE>()?
         } else {
             build_list_len
@@ -109,8 +112,7 @@ impl BuildAI {
 
         let num_build_items = input.read_u32::<LE>()?;
         for _ in 0..num_build_items {
-            ai.build_queue
-                .push(BuildItem::read_from(&mut input, version)?);
+            ai.build_queue.push(BuildItem::read_from(input)?);
         }
 
         for _ in 0..600 {
@@ -137,13 +139,14 @@ pub struct ConstructionItem {
     pub built: u32,
 }
 
-impl ConstructionItem {
-    pub fn read_from(mut input: impl Read, _version: f32) -> Result<Self> {
+impl ReadableHeaderElement for ConstructionItem {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         let mut item = ConstructionItem {
             name: input.read_u32_length_prefixed_str()?,
             type_id: input.read_u32::<LE>()?,
             ..Default::default()
         };
+
         let _a2 = input.read_u32::<LE>()?;
         let _v27 = input.read_u32::<LE>()?;
         item.x = input.read_f32::<LE>()?;
@@ -159,6 +162,7 @@ impl ConstructionItem {
         Ok(item)
     }
 }
+
 #[derive(Debug, Default, Clone)]
 pub struct ConstructionAI {
     pub plan_name: Option<String>,
@@ -168,8 +172,8 @@ pub struct ConstructionAI {
     pub random_construction_lots: Vec<ConstructionItem>,
 }
 
-impl ConstructionAI {
-    pub fn read_from(mut input: impl Read, version: f32) -> Result<Self> {
+impl ReadableHeaderElement for ConstructionAI {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         let mut ai = Self::default();
         let num_lots = input.read_u32::<LE>()?;
         ai.plan_name = input.read_u32_length_prefixed_str()?;
@@ -181,12 +185,12 @@ impl ConstructionAI {
         ai.map_size = (input.read_u32::<LE>()?, input.read_u32::<LE>()?);
         for _ in 0..num_lots {
             ai.construction_lots
-                .push(ConstructionItem::read_from(&mut input, version)?);
+                .push(ConstructionItem::read_from(input)?);
         }
         let num_lots = input.read_u32::<LE>()?;
         for _ in 0..num_lots {
             ai.random_construction_lots
-                .push(ConstructionItem::read_from(&mut input, version)?);
+                .push(ConstructionItem::read_from(input)?);
         }
         Ok(ai)
     }
@@ -201,8 +205,8 @@ pub struct DiplomacyAI {
     pub changeable: [u8; 10],
 }
 
-impl DiplomacyAI {
-    pub fn read_from(mut input: impl Read) -> Result<Self> {
+impl ReadableHeaderElement for DiplomacyAI {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         let mut ai = Self::default();
         for i in 0..10 {
             ai.dislike[i] = input.read_u32::<LE>()?;
@@ -218,8 +222,8 @@ pub struct EmotionalAI {
     pub state: [u32; 6],
 }
 
-impl EmotionalAI {
-    pub fn read_from(mut input: impl Read) -> Result<Self> {
+impl ReadableHeaderElement for EmotionalAI {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         let mut ai = Self::default();
         input.read_u32_into::<LE>(&mut ai.state)?;
         Ok(ai)
@@ -243,12 +247,12 @@ pub struct ImportantObjectMemory {
     pub is_garrisoned: u32,
 }
 
-impl ImportantObjectMemory {
-    pub fn read_from(mut input: impl Read, _version: f32) -> Result<Self> {
+impl ReadableHeaderElement for ImportantObjectMemory {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         Ok(ImportantObjectMemory {
-            id: read_opt_u32(&mut input)?,
-            unit_type_id: read_opt_u16(&mut input)?,
-            unit_class: read_opt_u16(&mut input)?,
+            id: read_opt_u32(input)?,
+            unit_type_id: read_opt_u16(input)?,
+            unit_class: read_opt_u16(input)?,
             location: (input.read_u8()?, input.read_u8()?, input.read_u8()?),
             owner: input.read_u8()?.into(),
             hit_points: input.read_u16::<LE>()?,
@@ -257,7 +261,7 @@ impl ImportantObjectMemory {
             damage_capability: input.read_f32::<LE>()?,
             rate_of_fire: input.read_f32::<LE>()?,
             range: input.read_f32::<LE>()?,
-            time_seen: read_opt_u32(&mut input)?,
+            time_seen: read_opt_u32(input)?,
             is_garrisoned: input.read_u32::<LE>()?,
         })
     }
@@ -270,9 +274,9 @@ pub struct BuildingLot {
     pub location: (u8, u8),
 }
 
-impl BuildingLot {
-    pub fn read_from(mut input: impl Read) -> Result<Self> {
-        let unit_type_id = read_opt_u32(&mut input)?;
+impl ReadableHeaderElement for BuildingLot {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
+        let unit_type_id = read_opt_u32(input)?;
         let status = input.read_u8()?;
         let x = input.read_u8()?;
         let y = input.read_u8()?;
@@ -297,21 +301,21 @@ pub struct WallLine {
     pub line_end: (u32, u32),
 }
 
-impl WallLine {
-    pub fn read_from(mut input: impl Read, version: f32) -> Result<Self> {
+impl ReadableHeaderElement for WallLine {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         let mut line = Self::default();
-        if version >= 10.78 {
+        if input.version() >= 10.78 {
             line.line_type = input.read_u32::<LE>()?;
         }
-        line.wall_type = read_opt_u32(&mut input)?;
-        if version >= 10.78 {
+        line.wall_type = read_opt_u32(input)?;
+        if input.version() >= 10.78 {
             line.gate_count = input.read_u32::<LE>()?;
         }
         line.segment_count = input.read_u32::<LE>()?;
-        if version >= 11.34 {
+        if input.version() >= 11.34 {
             line.invisible_segment_count = input.read_u32::<LE>()?;
         }
-        if version >= 11.29 {
+        if input.version() >= 11.29 {
             line.unfinished_segment_count = input.read_u32::<LE>()?;
         }
         line.line_start = (input.read_u32::<LE>()?, input.read_u32::<LE>()?);
@@ -334,10 +338,10 @@ pub struct PerimeterWall {
     pub next_segment_to_refresh: u32,
 }
 
-impl PerimeterWall {
-    pub fn read_from(mut input: impl Read, version: f32) -> Result<Self> {
+impl ReadableHeaderElement for PerimeterWall {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         let mut wall = PerimeterWall {
-            enabled: if version >= 11.22 {
+            enabled: if input.version() >= 11.22 {
                 input.read_u32::<LE>()? != 0
             } else {
                 true
@@ -345,16 +349,16 @@ impl PerimeterWall {
             ..Default::default()
         };
         let num_lines = input.read_u32::<LE>()?;
-        if version >= 11.20 {
+        if input.version() >= 11.20 {
             wall.gate_count = input.read_u32::<LE>()?;
             wall.percentage_complete = input.read_u32::<LE>()?;
             wall.segment_count = input.read_u32::<LE>()?;
-            if version >= 11.34 {
+            if input.version() >= 11.34 {
                 wall.invisible_segment_count = input.read_u32::<LE>()?;
             }
             wall.unfinished_segment_count = input.read_u32::<LE>()?;
         }
-        if version >= 11.29 {
+        if input.version() >= 11.29 {
             wall.next_line_to_refresh = input.read_u32::<LE>()?;
             wall.next_segment_to_refresh = input.read_u32::<LE>()?;
         }
@@ -362,7 +366,7 @@ impl PerimeterWall {
         wall.lines = {
             let mut list = vec![];
             for _ in 0..num_lines {
-                list.push(WallLine::read_from(&mut input, version)?);
+                list.push(WallLine::read_from(input)?);
             }
             list
         };
@@ -387,10 +391,10 @@ pub struct AttackMemory {
     pub play: Option<i32>,
 }
 
-impl AttackMemory {
-    pub fn read_from(mut input: impl Read) -> Result<Self> {
+impl ReadableHeaderElement for AttackMemory {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         let mut mem = AttackMemory {
-            id: read_opt_u32(&mut input)?,
+            id: read_opt_u32(input)?,
             typ: input.read_u8()?,
             min_x: input.read_u8()?,
             min_y: input.read_u8()?,
@@ -410,8 +414,8 @@ impl AttackMemory {
         mem.kills = input.read_u16::<LE>()?;
         mem.success = input.read_u8()? != 0;
         input.skip(1)?;
-        mem.timestamp = read_opt_u32(&mut input)?;
-        mem.play = read_opt_u32(&mut input)?;
+        mem.timestamp = read_opt_u32(input)?;
+        mem.play = read_opt_u32(input)?;
         Ok(mem)
     }
 }
@@ -430,8 +434,8 @@ pub struct ResourceMemory {
     pub attacked_time: Option<u32>,
 }
 
-impl ResourceMemory {
-    pub fn read_from(mut input: impl Read, version: f32) -> Result<Self> {
+impl ReadableHeaderElement for ResourceMemory {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         let mut mem = ResourceMemory {
             id: input.read_u32::<LE>()?.into(),
             location: (input.read_u8()?, input.read_u8()?),
@@ -444,8 +448,9 @@ impl ResourceMemory {
             dropsite_id: input.read_u32::<LE>()?.into(),
             ..Default::default()
         };
-        if version >= 10.91 {
-            mem.attacked_time = read_opt_u32(&mut input)?;
+
+        if input.version() >= 10.91 {
+            mem.attacked_time = read_opt_u32(input)?;
         }
         Ok(mem)
     }
@@ -460,8 +465,8 @@ pub struct InfluenceMap {
     pub values: Vec<i8>,
 }
 
-impl InfluenceMap {
-    pub fn read_from(mut input: impl Read) -> Result<Self> {
+impl ReadableHeaderElement for InfluenceMap {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         let mut map = Self::default();
         map.width = input.read_u32::<LE>()?;
         map.height = input.read_u32::<LE>()?;
@@ -480,8 +485,8 @@ pub struct QuadrantLog {
     pub attacks_by_us: u32,
 }
 
-impl QuadrantLog {
-    pub fn read_from(mut input: impl Read) -> Result<Self> {
+impl ReadableHeaderElement for QuadrantLog {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         let explored_tiles = input.read_u32::<LE>()?;
         let attacks_on_us = input.read_u32::<LE>()?;
         let attacks_by_us = input.read_u32::<LE>()?;
@@ -516,9 +521,9 @@ pub struct InformationAI {
     pub quadrant_log: [QuadrantLog; 4],
 }
 
-impl InformationAI {
+impl ReadableHeaderElement for InformationAI {
     #[allow(clippy::cognitive_complexity)]
-    pub fn read_from(mut input: impl Read, version: f32) -> Result<Self> {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         let mut ai = Self::default();
         for _ in 0..4096 {
             let _garbage = input.read_u32::<LE>()?;
@@ -557,7 +562,7 @@ impl InformationAI {
             let max_important_object_memory = input.read_u32::<LE>()?;
             let mut important_objects = vec![];
             for _ in 0..max_important_object_memory {
-                let important_object = ImportantObjectMemory::read_from(&mut input, version)?;
+                let important_object = ImportantObjectMemory::read_from(input)?;
                 if important_object.id.is_none() {
                     continue;
                 }
@@ -570,7 +575,7 @@ impl InformationAI {
             let len = input.read_u32::<LE>()?;
             let mut lots = vec![];
             for _ in 0..len {
-                let lot = BuildingLot::read_from(&mut input)?;
+                let lot = BuildingLot::read_from(input)?;
                 if lot.unit_type_id.is_none() {
                     continue;
                 }
@@ -580,15 +585,15 @@ impl InformationAI {
         };
 
         ai.perimeter_walls = (
-            PerimeterWall::read_from(&mut input, version)?,
-            PerimeterWall::read_from(&mut input, version)?,
+            PerimeterWall::read_from(input)?,
+            PerimeterWall::read_from(input)?,
         );
 
         ai.attack_memories = {
             let len = input.read_u32::<LE>()?;
             let mut attacks = vec![];
             for _ in 0..len {
-                let attack = AttackMemory::read_from(&mut input)?;
+                let attack = AttackMemory::read_from(input)?;
                 // if attack.unit_type_id.is_none() {
                 //     continue;
                 // }
@@ -597,17 +602,17 @@ impl InformationAI {
             attacks
         };
 
-        ai.important_object_ids = read_id_list(&mut input)?;
-        ai.important_unit_ids = read_id_list(&mut input)?;
-        ai.important_misc_ids = read_id_list(&mut input)?;
-        ai.items_to_defend = read_id_list(&mut input)?;
-        ai.player_buildings = read_id_list(&mut input)?;
-        ai.player_objects = read_id_list(&mut input)?;
+        ai.important_object_ids = read_id_list(input)?;
+        ai.important_unit_ids = read_id_list(input)?;
+        ai.important_misc_ids = read_id_list(input)?;
+        ai.items_to_defend = read_id_list(input)?;
+        ai.player_buildings = read_id_list(input)?;
+        ai.player_objects = read_id_list(input)?;
 
         ai.object_counts = {
-            let num_counts = if version < 11.51 {
+            let num_counts = if input.version() < 11.51 {
                 750
-            } else if version < 11.65 {
+            } else if input.version() < 11.65 {
                 850
             } else {
                 900
@@ -620,26 +625,26 @@ impl InformationAI {
 
         let _building_count = input.read_u32::<LE>()?;
 
-        ai.path_map = InfluenceMap::read_from(&mut input)?;
+        ai.path_map = InfluenceMap::read_from(input)?;
         let _last_wall_position = (input.read_i32::<LE>()?, input.read_i32::<LE>()?);
         let _last_wall_position_2 = (input.read_i32::<LE>()?, input.read_i32::<LE>()?);
 
-        if version < 10.78 {
+        if input.version() < 10.78 {
             input.skip(4 + 4 * 16)?;
         }
 
         let _save_learn_information = input.read_u32::<LE>()? != 0;
         let _learn_path = input.read_u32_length_prefixed_str()?;
 
-        if version < 11.25 {
+        if input.version() < 11.25 {
             input.skip(0xFF)?;
         }
 
         ai.quadrant_log = [
-            QuadrantLog::read_from(&mut input)?,
-            QuadrantLog::read_from(&mut input)?,
-            QuadrantLog::read_from(&mut input)?,
-            QuadrantLog::read_from(&mut input)?,
+            QuadrantLog::read_from(input)?,
+            QuadrantLog::read_from(input)?,
+            QuadrantLog::read_from(input)?,
+            QuadrantLog::read_from(input)?,
         ];
 
         let _max_resources = [
@@ -660,7 +665,7 @@ impl InformationAI {
             for (list, &num) in resources.iter_mut().zip(num_resources.iter()) {
                 list.reserve(num as usize);
                 for _ in 0..num {
-                    list.push(ResourceMemory::read_from(&mut input, version)?);
+                    list.push(ResourceMemory::read_from(input)?);
                 }
             }
             resources
@@ -689,18 +694,18 @@ impl InformationAI {
         ];
         let _found_forest_tiles = input.read_u32::<LE>()?;
 
-        if version < 10.85 {
+        if input.version() < 10.85 {
             input.skip(64_000)?;
         }
 
-        if version >= 10.90 {
+        if input.version() >= 10.90 {
             let mut relics_victory = [0; 9];
             input.read_exact(&mut relics_victory)?;
             let mut wonder_victory = [0; 9];
             input.read_exact(&mut wonder_victory)?;
         }
 
-        if version >= 10.94 {
+        if input.version() >= 10.94 {
             let should_farm = input.read_u32::<LE>()?;
             let have_seen_forage = input.read_u32::<LE>()?;
             let have_seen_gold = input.read_u32::<LE>()?;
@@ -712,28 +717,28 @@ impl InformationAI {
                 have_seen_stone,
             );
         }
-        if version >= 10.95 {
+        if input.version() >= 10.95 {
             let have_seen_forest = input.read_u32::<LE>()?;
             dbg!(have_seen_forest);
         }
 
-        if version > 10.99 {
+        if input.version() > 10.99 {
             let last_player_count_refresh_time = input.read_u32::<LE>()?;
             dbg!(last_player_count_refresh_time);
         }
 
-        let player_unit_counts_size = if version >= 11.51 { 120 } else { 102 };
+        let player_unit_counts_size = if input.version() >= 11.51 { 120 } else { 102 };
         let mut player_unit_counts = vec![vec![0; player_unit_counts_size as usize]; 8];
         for unit_counts in player_unit_counts.iter_mut() {
             input.read_u32_into::<LE>(unit_counts)?;
         }
 
-        if version >= 11.09 {
+        if input.version() >= 11.09 {
             let mut player_total_building_counts = [0; 8];
             input.read_u32_into::<LE>(&mut player_total_building_counts)?;
 
             let mut player_real_total_building_counts = [0; 8];
-            if version >= 11.21 {
+            if input.version() >= 11.21 {
                 input.read_u32_into::<LE>(&mut player_real_total_building_counts)?;
             }
 
@@ -757,13 +762,15 @@ pub struct ResourceAI {
     pub num_resources: u32,
 }
 
-impl ResourceAI {
-    pub fn read_from(mut input: impl Read) -> Result<Self> {
+impl ReadableHeaderElement for ResourceAI {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         let num_resources = input.read_u32::<LE>()?;
         Ok(Self { num_resources })
     }
+}
 
-    pub fn write_to(&self, mut output: impl Write) -> Result<()> {
+impl WritableHeaderElement for ResourceAI {
+    fn write_to<W: Write>(&self, output: &mut W) -> Result<()> {
         output.write_u32::<LE>(self.num_resources)?;
         Ok(())
     }
@@ -787,32 +794,28 @@ pub struct StrategyAI {
     pub expert_list_id: Option<u32>,
 }
 
-impl StrategyAI {
-    pub fn read_from(mut input: impl Read, version: f32) -> Result<Self> {
+impl ReadableHeaderElement for StrategyAI {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         Ok(StrategyAI {
             current_victory_condition: input.read_u32::<LE>()?,
             target_id: input.read_u32::<LE>()?,
             second_target_id: input.read_u32::<LE>()?,
             second_target_type: input.read_u32::<LE>()?,
-            target_point: Waypoint::read_from(&mut input)?,
-            target_point_2: Waypoint::read_from(&mut input)?,
+            target_point: Waypoint::read_from(input)?,
+            target_point_2: Waypoint::read_from(input)?,
             target_attribute: input.read_u32::<LE>()?,
             target_number: input.read_u32::<LE>()?,
             victory_condition_change_timeout: input.read_u32::<LE>()?,
             ruleset_name: input.read_u32_length_prefixed_str()?,
-            vc_ruleset: read_id_list(&mut input)?,
-            executing_rules: read_id_list(&mut input)?,
-            idle_rules: read_id_list(&mut input)?,
-            expert_list_id: if version >= 9.71 {
+            vc_ruleset: read_id_list(input)?,
+            executing_rules: read_id_list(input)?,
+            idle_rules: read_id_list(input)?,
+            expert_list_id: if input.version() >= 9.71 {
                 Some(input.read_u32::<LE>()?)
             } else {
                 None
             },
         })
-    }
-
-    pub fn write_to(&self, _output: impl Write) -> Result<()> {
-        todo!()
     }
 }
 
@@ -841,11 +844,11 @@ pub struct TacticalAI {
     pub groups: Vec<()>,
 }
 
-impl TacticalAI {
-    pub fn read_from(mut input: impl Read, _version: f32) -> Result<Self> {
+impl ReadableHeaderElement for TacticalAI {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         let mut ai = TacticalAI {
-            civilians: read_id_list(&mut input)?,
-            civilian_explorers: read_id_list(&mut input)?,
+            civilians: read_id_list(input)?,
+            civilian_explorers: read_id_list(input)?,
             ..Default::default()
         };
 
@@ -854,20 +857,16 @@ impl TacticalAI {
 
         // FIXME: more stuff here
 
-        ai.soldiers = read_id_list(&mut input)?;
-        ai.ungrouped_soldiers = read_id_list(&mut input)?;
-        ai.boats = read_id_list(&mut input)?;
-        ai.war_boats = read_id_list(&mut input)?;
-        ai.fishing_boats = read_id_list(&mut input)?;
-        ai.trade_boats = read_id_list(&mut input)?;
-        ai.transport_boats = read_id_list(&mut input)?;
-        ai.artifacts = read_id_list(&mut input)?;
-        ai.trade_carts = read_id_list(&mut input)?;
+        ai.soldiers = read_id_list(input)?;
+        ai.ungrouped_soldiers = read_id_list(input)?;
+        ai.boats = read_id_list(input)?;
+        ai.war_boats = read_id_list(input)?;
+        ai.fishing_boats = read_id_list(input)?;
+        ai.trade_boats = read_id_list(input)?;
+        ai.transport_boats = read_id_list(input)?;
+        ai.artifacts = read_id_list(input)?;
+        ai.trade_carts = read_id_list(input)?;
 
-        todo!()
-    }
-
-    pub fn write_to(&self, _output: impl Write, _version: f32) -> Result<()> {
         todo!()
     }
 }
@@ -884,16 +883,16 @@ pub struct PlayerAI {
     pub strategy_ai: StrategyAI,
 }
 
-impl PlayerAI {
-    pub fn read_from(mut input: impl Read, version: f32) -> Result<Self> {
-        let main_ai = MainAI::read_from(&mut input)?;
-        let build_ai = BuildAI::read_from(&mut input, version)?;
-        let construction_ai = ConstructionAI::read_from(&mut input, version)?;
-        let diplomacy_ai = DiplomacyAI::read_from(&mut input)?;
-        let emotional_ai = EmotionalAI::read_from(&mut input)?;
-        let information_ai = InformationAI::read_from(&mut input, version)?;
-        let resource_ai = ResourceAI::read_from(&mut input)?;
-        let strategy_ai = StrategyAI::read_from(&mut input, version)?;
+impl ReadableHeaderElement for PlayerAI {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
+        let main_ai = MainAI::read_from(input)?;
+        let build_ai = BuildAI::read_from(input)?;
+        let construction_ai = ConstructionAI::read_from(input)?;
+        let diplomacy_ai = DiplomacyAI::read_from(input)?;
+        let emotional_ai = EmotionalAI::read_from(input)?;
+        let information_ai = InformationAI::read_from(input)?;
+        let resource_ai = ResourceAI::read_from(input)?;
+        let strategy_ai = StrategyAI::read_from(input)?;
 
         Ok(Self {
             main_ai,
@@ -906,13 +905,9 @@ impl PlayerAI {
             strategy_ai,
         })
     }
-
-    pub fn write_to(&self, _output: impl Write, _version: f32) -> Result<()> {
-        todo!()
-    }
 }
 
-fn read_id_list<T: From<u32>>(mut input: impl Read) -> Result<Vec<T>> {
+fn read_id_list<T: From<u32>, R: Read>(input: &mut R) -> Result<Vec<T>> {
     let len = input.read_u32::<LE>()?;
     let mut ids = vec![];
     for _ in 0..len {

--- a/crates/genie-rec/src/element.rs
+++ b/crates/genie-rec/src/element.rs
@@ -1,0 +1,45 @@
+use crate::reader::RecordingHeaderReader;
+use std::io::{Read, Write};
+
+pub trait OptionalReadableElement: Sized {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> crate::Result<Option<Self>>;
+}
+
+impl<T: OptionalReadableElement> ReadableElement<Option<T>> for T {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> crate::Result<Option<T>> {
+        OptionalReadableElement::read_from(input)
+    }
+}
+
+pub trait ReadableElement<T>: Sized {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> crate::Result<T>;
+}
+
+pub trait ReadableHeaderElement: Sized {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> crate::Result<Self>;
+}
+
+impl<T: ReadableHeaderElement> ReadableElement<T> for T {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> crate::Result<T> {
+        ReadableHeaderElement::read_from(input)
+    }
+}
+
+pub trait WritableElement<T> {
+    fn write_to<W: Write>(element: &T, output: &mut W) -> crate::Result<()>;
+}
+
+pub trait WritableHeaderElement {
+    fn write_to<W: Write>(&self, output: &mut W) -> crate::Result<()> {
+        // we need to use `output` otherwise we'll get warnings that it's not used
+        // prefixing it would make any traits auto completed also be prefixed with _ and that's annoying
+        let _ = output;
+        unimplemented!()
+    }
+}
+
+impl<T: WritableHeaderElement> WritableElement<T> for T {
+    fn write_to<W: Write>(element: &T, output: &mut W) -> crate::Result<()> {
+        WritableHeaderElement::write_to(element, output)
+    }
+}

--- a/crates/genie-rec/src/lib.rs
+++ b/crates/genie-rec/src/lib.rs
@@ -20,22 +20,28 @@
 
 pub mod actions;
 pub mod ai;
+pub mod element;
 pub mod header;
 pub mod map;
 pub mod player;
+pub mod reader;
 pub mod string_table;
 pub mod unit;
 pub mod unit_action;
 pub mod unit_type;
+pub mod version;
 
 use crate::actions::{Action, Meta};
+use crate::element::ReadableHeaderElement;
+use crate::reader::{RecordingHeaderReader, SmallBufReader};
 use byteorder::{ReadBytesExt, LE};
 use flate2::bufread::DeflateDecoder;
 use genie_scx::DLCOptions;
 use genie_support::{fallible_try_from, fallible_try_into, infallible_try_into};
 pub use header::Header;
-use std::fmt::{self, Debug, Display};
+use std::fmt::Debug;
 use std::io::{self, BufRead, BufReader, Read, Seek, SeekFrom};
+pub use version::*;
 
 /// ID identifying a player (0-8).
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -98,37 +104,6 @@ fallible_try_from!(ObjectID, i16);
 fallible_try_from!(ObjectID, i32);
 fallible_try_into!(ObjectID, i16);
 fallible_try_into!(ObjectID, i32);
-
-/// The game data version string. In practice, this does not really reflect the game version.
-#[derive(Clone, Copy, PartialEq, Eq)]
-pub struct GameVersion([u8; 8]);
-
-impl Default for GameVersion {
-    fn default() -> Self {
-        Self([0; 8])
-    }
-}
-
-impl Debug for GameVersion {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", std::str::from_utf8(&self.0).unwrap())
-    }
-}
-
-impl Display for GameVersion {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", std::str::from_utf8(&self.0).unwrap())
-    }
-}
-
-impl GameVersion {
-    /// Read the game version string from an input stream.
-    pub fn read_from(mut input: impl Read) -> Result<Self> {
-        let mut game_version = [0; 8];
-        input.read_exact(&mut game_version)?;
-        Ok(Self(game_version))
-    }
-}
 
 ///
 #[derive(Debug, thiserror::Error)]
@@ -302,53 +277,6 @@ pub struct HDGameOptions {
     pub scenario_player_indices: Vec<i32>,
 }
 
-/// A struct implementing `BufRead` that uses a small, single-use, stack-allocated buffer, intended
-/// for reading only the first few bytes from a file.
-struct SmallBufReader<R>
-where
-    R: Read,
-{
-    buffer: [u8; 256],
-    pointer: usize,
-    reader: R,
-}
-
-impl<R> SmallBufReader<R>
-where
-    R: Read,
-{
-    fn new(reader: R) -> Self {
-        Self {
-            buffer: [0; 256],
-            pointer: 0,
-            reader,
-        }
-    }
-}
-
-impl<R> Read for SmallBufReader<R>
-where
-    R: Read,
-{
-    fn read(&mut self, output: &mut [u8]) -> io::Result<usize> {
-        self.reader.read(output)
-    }
-}
-
-impl<R> BufRead for SmallBufReader<R>
-where
-    R: Read,
-{
-    fn fill_buf(&mut self) -> io::Result<&[u8]> {
-        self.reader.read_exact(&mut self.buffer[self.pointer..])?;
-        Ok(&self.buffer[self.pointer..])
-    }
-
-    fn consume(&mut self, len: usize) {
-        self.pointer += len;
-    }
-}
-
 /// Recorded game reader.
 pub struct RecordedGame<R>
 where
@@ -424,7 +352,7 @@ where
         self.seek_to_first_header()?;
         let reader = BufReader::new(&mut self.inner).take(self.header_end - self.header_start);
         let deflate = DeflateDecoder::new(reader);
-        let header = Header::read_from(deflate)?;
+        let header = Header::read_from(&mut RecordingHeaderReader::new(deflate))?;
         Ok(header)
     }
 

--- a/crates/genie-rec/src/map.rs
+++ b/crates/genie-rec/src/map.rs
@@ -1,3 +1,5 @@
+use crate::element::{ReadableHeaderElement, WritableHeaderElement};
+use crate::reader::RecordingHeaderReader;
 use crate::Result;
 use byteorder::{ReadBytesExt, WriteBytesExt, LE};
 use genie_support::ReadSkipExt;
@@ -16,9 +18,9 @@ pub struct Tile {
     pub original_terrain: Option<u8>,
 }
 
-impl Tile {
+impl ReadableHeaderElement for Tile {
     /// Read a tile from an input stream.
-    pub fn read_from(mut input: impl Read) -> Result<Self> {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         let terrain = input.read_u8()?;
         let (terrain, elevation, original_terrain) = if terrain == 0xFF {
             (input.read_u8()?, input.read_u8()?, Some(input.read_u8()?))
@@ -31,9 +33,11 @@ impl Tile {
             original_terrain,
         })
     }
+}
 
+impl WritableHeaderElement for Tile {
     /// Write a tile to an output stream.
-    pub fn write_to(&self, mut output: impl Write) -> Result<()> {
+    fn write_to<W: Write>(&self, output: &mut W) -> Result<()> {
         match self.original_terrain {
             Some(t) => {
                 output.write_u8(0xFF)?;
@@ -74,39 +78,6 @@ impl Default for MapZone {
 }
 
 impl MapZone {
-    pub fn read_from(mut input: impl Read, map_size: (u32, u32)) -> Result<Self> {
-        let mut zone = Self::default();
-        input.read_i8_into(&mut zone.info)?;
-        input.read_i32_into::<LE>(&mut zone.tiles)?;
-        zone.zone_map = vec![0; (map_size.0 * map_size.1).try_into().unwrap()];
-        input.read_i8_into(&mut zone.zone_map)?;
-
-        let num_rules = input.read_u32::<LE>()?;
-        zone.passability_rules = vec![0.0; num_rules.try_into().unwrap()];
-        input.read_f32_into::<LE>(&mut zone.passability_rules)?;
-
-        zone.num_zones = input.read_u32::<LE>()?;
-        Ok(zone)
-    }
-
-    pub fn write_to(&self, mut output: impl Write) -> Result<()> {
-        for val in &self.info {
-            output.write_i8(*val)?;
-        }
-        for val in &self.tiles {
-            output.write_i32::<LE>(*val)?;
-        }
-        for val in &self.zone_map {
-            output.write_i8(*val)?;
-        }
-        output.write_u32::<LE>(self.passability_rules.len().try_into().unwrap())?;
-        for val in &self.passability_rules {
-            output.write_f32::<LE>(*val)?;
-        }
-        output.write_u32::<LE>(self.num_zones)?;
-        Ok(())
-    }
-
     pub fn info(&self) -> &[i8] {
         assert_eq!(self.info.len(), 255);
         &self.info
@@ -128,6 +99,43 @@ impl MapZone {
     }
 }
 
+impl ReadableHeaderElement for MapZone {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
+        let mut zone = Self::default();
+        input.read_i8_into(&mut zone.info)?;
+        input.read_i32_into::<LE>(&mut zone.tiles)?;
+        zone.zone_map = vec![0; input.tile_count()];
+        input.read_i8_into(&mut zone.zone_map)?;
+
+        let num_rules = input.read_u32::<LE>()?;
+        zone.passability_rules = vec![0.0; num_rules as usize];
+        input.read_f32_into::<LE>(&mut zone.passability_rules)?;
+
+        zone.num_zones = input.read_u32::<LE>()?;
+        Ok(zone)
+    }
+}
+
+impl WritableHeaderElement for MapZone {
+    fn write_to<W: Write>(&self, output: &mut W) -> Result<()> {
+        for val in &self.info {
+            output.write_i8(*val)?;
+        }
+        for val in &self.tiles {
+            output.write_i32::<LE>(*val)?;
+        }
+        for val in &self.zone_map {
+            output.write_i8(*val)?;
+        }
+        output.write_u32::<LE>(self.passability_rules.len().try_into().unwrap())?;
+        for val in &self.passability_rules {
+            output.write_f32::<LE>(*val)?;
+        }
+        output.write_u32::<LE>(self.num_zones)?;
+        Ok(())
+    }
+}
+
 ///
 #[derive(Debug, Default, Clone)]
 pub struct VisibilityMap {
@@ -139,8 +147,8 @@ pub struct VisibilityMap {
     pub visibility: Vec<u32>,
 }
 
-impl VisibilityMap {
-    pub fn read_from(mut input: impl Read) -> Result<Self> {
+impl ReadableHeaderElement for VisibilityMap {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         let width = input.read_u32::<LE>()?;
         let height = input.read_u32::<LE>()?;
         let mut visibility = vec![0; (width * height).try_into().unwrap()];
@@ -151,8 +159,10 @@ impl VisibilityMap {
             visibility,
         })
     }
+}
 
-    pub fn write_to(&self, mut output: impl Write) -> Result<()> {
+impl WritableHeaderElement for VisibilityMap {
+    fn write_to<W: Write>(&self, output: &mut W) -> Result<()> {
         output.write_u32::<LE>(self.width)?;
         output.write_u32::<LE>(self.height)?;
         for value in &self.visibility {
@@ -181,25 +191,26 @@ pub struct Map {
     pub visibility: VisibilityMap,
 }
 
-impl Map {
+impl ReadableHeaderElement for Map {
     /// Read map data from an input stream.
-    pub fn read_from(mut input: impl Read) -> Result<Self> {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         let mut map = Map {
             width: input.read_u32::<LE>()?,
             height: input.read_u32::<LE>()?,
             ..Default::default()
         };
+
+        input.set_map_size(map.width, map.height);
         let num_zones = input.read_u32::<LE>()?;
         map.zones = Vec::with_capacity(num_zones.try_into().unwrap());
         for _ in 0..num_zones {
-            map.zones
-                .push(MapZone::read_from(&mut input, (map.width, map.height))?);
+            map.zones.push(MapZone::read_from(input)?);
         }
         map.all_visible = input.read_u8()? != 0;
         map.fog_of_war = input.read_u8()? != 0;
         map.tiles = Vec::with_capacity((map.width * map.height).try_into().unwrap());
         for _ in 0..(map.width * map.height) {
-            map.tiles.push(Tile::read_from(&mut input)?);
+            map.tiles.push(Tile::read_from(input)?);
         }
 
         let _umv = {
@@ -212,13 +223,8 @@ impl Map {
             }
         };
 
-        map.visibility = VisibilityMap::read_from(&mut input)?;
+        map.visibility = VisibilityMap::read_from(input)?;
 
         Ok(map)
-    }
-
-    /// Write map data to an output stream.
-    pub fn write_to(&self, _output: impl Write) -> Result<()> {
-        unimplemented!()
     }
 }

--- a/crates/genie-rec/src/player.rs
+++ b/crates/genie-rec/src/player.rs
@@ -1,4 +1,6 @@
 use crate::ai::PlayerAI;
+use crate::element::{OptionalReadableElement, ReadableHeaderElement, WritableHeaderElement};
+use crate::reader::RecordingHeaderReader;
 use crate::unit::Unit;
 use crate::unit_type::CompactUnitType;
 use crate::{ObjectID, PlayerID, Result};
@@ -46,16 +48,23 @@ impl Player {
         &self.name
     }
 
+    pub fn read_info<R: Read>(&mut self, input: &mut RecordingHeaderReader<R>) -> Result<()> {
+        self.victory = VictoryConditions::read_from(input, true)?;
+        Ok(())
+    }
+}
+
+impl ReadableHeaderElement for Player {
     #[allow(clippy::cognitive_complexity)]
-    pub fn read_from(mut input: impl Read, version: f32, num_players: u8) -> Result<Self> {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         let mut player = Player {
             player_type: input.read_u8()?,
             ..Default::default()
         };
-        if version >= 10.55 {
+        if input.version() >= 10.55 {
             assert_eq!(input.read_u8()?, 11);
         }
-        player.relations = vec![0; usize::from(num_players)];
+        player.relations = vec![0; input.num_players() as usize];
         input.read_exact(&mut player.relations)?;
         input.read_u32_into::<LE>(&mut player.diplomacy)?;
         player.allied_los = input.read_u32::<LE>()? != 0;
@@ -63,20 +72,21 @@ impl Player {
         player.name = input
             .read_u16_length_prefixed_str()?
             .unwrap_or_else(String::new);
-        if version >= 10.55 {
+        dbg!(input.version());
+        if input.version() >= 10.55 {
             assert_eq!(input.read_u8()?, 22);
         }
         let num_attributes = input.read_u32::<LE>()?;
-        if version >= 10.55 {
+        if input.version() >= 10.55 {
             assert_eq!(input.read_u8()?, 33);
         }
         player.attributes = vec![0.0; num_attributes.try_into().unwrap()];
         input.read_f32_into::<LE>(&mut player.attributes)?;
-        if version >= 10.55 {
+        if input.version() >= 10.55 {
             assert_eq!(input.read_u8()?, 11);
         }
         player.initial_view = (input.read_f32::<LE>()?, input.read_f32::<LE>()?);
-        if version >= 11.62 {
+        if input.version() >= 11.62 {
             let num_saved_views = input.read_i32::<LE>()?;
             // saved view count can be negative
             player.saved_views = vec![(0.0, 0.0); num_saved_views.try_into().unwrap_or(0)];
@@ -89,20 +99,20 @@ impl Player {
         player.civilization_id = input.read_u8()?.into();
         player.game_status = input.read_u8()?;
         player.resigned = input.read_u8()? != 0;
-        if version >= 10.55 {
+        if input.version() >= 10.55 {
             assert_eq!(input.read_u8()?, 11);
         }
         let _color = input.read_u8()?;
-        if version >= 10.55 {
+        if input.version() >= 10.55 {
             assert_eq!(input.read_u8()?, 11);
         }
         let _pathing_attempt_cap = input.read_u32::<LE>()?;
         let _pathing_delay_cap = input.read_u32::<LE>()?;
 
         // Unit counts
-        let counts = if version >= 11.65 {
+        let counts = if input.version() >= 11.65 {
             (900, 100, 900, 100)
-        } else if version >= 11.51 {
+        } else if input.version() >= 11.51 {
             (850, 100, 850, 100)
         } else {
             (750, 100, 750, 100)
@@ -129,7 +139,7 @@ impl Player {
         let _column_to_line_distance = input.read_u32::<LE>()?;
         let _auto_formations = input.read_u32::<LE>()?;
         let _formations_influence_distance = input.read_f32::<LE>()?;
-        let _break_auto_formations_by_speed = if version >= 10.81 {
+        let _break_auto_formations_by_speed = if input.version() >= 10.81 {
             input.read_f32::<LE>()?
         } else {
             0.0
@@ -156,7 +166,7 @@ impl Player {
         );
 
         // view scrolling
-        if version >= 10.51 {
+        if input.version() >= 10.51 {
             let _scroll_vector = (input.read_f32::<LE>()?, input.read_f32::<LE>()?);
             let _scroll_end = (input.read_f32::<LE>()?, input.read_f32::<LE>()?);
             let _scroll_start = (input.read_f32::<LE>()?, input.read_f32::<LE>()?);
@@ -165,14 +175,14 @@ impl Player {
         }
 
         // AI state
-        if version >= 11.45 {
+        if input.version() >= 11.45 {
             let _easiest_reaction_percent = input.read_f32::<LE>()?;
             let _easier_reaction_percent = input.read_f32::<LE>()?;
             let _task_ungrouped_soldiers = input.read_u8()? != 0;
         }
 
         // selected units
-        if version >= 11.72 {
+        if input.version() >= 11.72 {
             let num_selections = input.read_u32::<LE>()?;
             let _selection = if num_selections > 0 {
                 let object_id: ObjectID = input.read_u32::<LE>()?.into();
@@ -187,7 +197,7 @@ impl Player {
             };
         }
 
-        if version >= 10.55 {
+        if input.version() >= 10.55 {
             assert_eq!(input.read_u8()?, 11);
             assert_eq!(input.read_u8()?, 11);
         }
@@ -197,7 +207,7 @@ impl Player {
         let _update_count_need_help = input.read_u32::<LE>()?;
 
         // ai attack data
-        if version >= 10.02 {
+        if input.version() >= 10.02 {
             let _alerted_enemy_count = input.read_u32::<LE>()?;
             let _regular_attack_count = input.read_u32::<LE>()?;
             let _regular_attack_mode = input.read_u8()?;
@@ -211,26 +221,26 @@ impl Player {
         let _update_time = input.read_f32::<LE>()?;
 
         // if is userpatch
-        if genie_support::f32_eq!(version, 11.97) {
-            player.userpatch_data = Some(UserPatchData::read_from(&mut input)?);
+        if genie_support::f32_eq!(input.version(), 11.97) {
+            player.userpatch_data = Some(UserPatchData::read_from(input)?);
         }
 
-        player.tech_state = PlayerTech::read_from(&mut input)?;
+        player.tech_state = PlayerTech::read_from(input)?;
 
         let _update_history_count = input.read_u32::<LE>()?;
-        player.history_info = HistoryInfo::read_from(&mut input, version)?;
+        player.history_info = HistoryInfo::read_from(input)?;
 
-        if version >= 5.30 {
+        if input.version() >= 5.30 {
             let _ruin_held_time = input.read_u32::<LE>()?;
             let _artifact_held_time = input.read_u32::<LE>()?;
         }
 
-        if version >= 10.55 {
+        if input.version() >= 10.55 {
             assert_eq!(input.read_u8()?, 11);
         }
 
         // diplomacy
-        if version >= 9.13 {
+        if input.version() >= 9.13 {
             let mut diplomacy = [0; 9];
             let mut intelligence = [0; 9];
             let mut trade = [0; 9];
@@ -240,32 +250,32 @@ impl Player {
                 intelligence[i] = input.read_u8()?;
                 trade[i] = input.read_u8()?;
 
-                offer.push(DiplomacyOffer::read_from(&mut input)?);
+                offer.push(DiplomacyOffer::read_from(input)?);
             }
             let _fealty = input.read_u16::<LE>()?;
         }
 
-        if version >= 10.55 {
+        if input.version() >= 10.55 {
             assert_eq!(input.read_u8()?, 11);
         }
 
         // off-map trade
-        if version >= 9.17 {
+        if input.version() >= 9.17 {
             let mut off_map_trade_route_explored = [0; 20];
             input.read_exact(&mut off_map_trade_route_explored)?;
         }
 
-        if version >= 9.18 {
+        if input.version() >= 9.18 {
             let mut off_map_trade_route_being_explored = [0; 20];
             input.read_exact(&mut off_map_trade_route_being_explored)?;
         }
 
-        if version >= 10.55 {
+        if input.version() >= 10.55 {
             assert_eq!(input.read_u8()?, 11);
         }
 
         // market trading
-        if version >= 9.22 {
+        if input.version() >= 9.22 {
             let _max_trade_amount = input.read_u32::<LE>()?;
             let _old_max_trade_amount = input.read_u32::<LE>()?;
             let _max_trade_limit = input.read_u32::<LE>()?;
@@ -279,35 +289,35 @@ impl Player {
             let _trade_refresh_rate = input.read_u32::<LE>()?;
         }
 
-        let _prod_queue_enabled = if version >= 9.67 {
+        let _prod_queue_enabled = if input.version() >= 9.67 {
             input.read_u8()? != 0
         } else {
             true
         };
 
         // ai dodging ability
-        if version >= 9.90 {
+        if input.version() >= 9.90 {
             let _chance_to_dodge_missiles = input.read_u8()?;
             let _chance_for_archers_to_maintain_distance = input.read_u8()?;
         }
 
-        let _open_gates_for_pathing_count = if version >= 11.42 {
+        let _open_gates_for_pathing_count = if input.version() >= 11.42 {
             input.read_u32::<LE>()?
         } else {
             0
         };
-        let _farm_queue_count = if version >= 11.57 {
+        let _farm_queue_count = if input.version() >= 11.57 {
             input.read_u32::<LE>()?
         } else {
             0
         };
-        let _nomad_build_lock = if version >= 11.75 {
+        let _nomad_build_lock = if input.version() >= 11.75 {
             input.read_u32::<LE>()? != 0
         } else {
             false
         };
 
-        if version >= 9.30 {
+        if input.version() >= 9.30 {
             let _old_kills = input.read_u32::<LE>()?;
             let _old_razings = input.read_u32::<LE>()?;
             let _battle_mode = input.read_u32::<LE>()?;
@@ -316,43 +326,43 @@ impl Player {
             let _total_razings = input.read_u32::<LE>()?;
         }
 
-        if version >= 9.31 {
+        if input.version() >= 9.31 {
             let _old_hit_points = input.read_u32::<LE>()?;
             let _total_hit_points = input.read_u32::<LE>()?;
         }
 
-        if version >= 9.32 {
+        if input.version() >= 9.32 {
             let mut old_player_kills = [0; 9];
             input.read_u32_into::<LE>(&mut old_player_kills)?;
         }
 
-        player.tech_tree = if version >= 9.38 {
-            Some(TechTree::read_from(&mut input)?)
+        player.tech_tree = if input.version() >= 9.38 {
+            Some(TechTree::read_from(&mut *input)?)
         } else {
             None
         };
 
-        if version >= 10.55 {
+        if input.version() >= 10.55 {
             assert_eq!(input.read_u8()?, 11);
         }
 
         let _player_ai = if player.player_type == 3 && input.read_u32::<LE>()? == 1 {
-            Some(PlayerAI::read_from(&mut input, version)?)
+            Some(PlayerAI::read_from(input)?)
         } else {
             None
         };
 
-        if version >= 10.55 {
+        if input.version() >= 10.55 {
             assert_eq!(input.read_u8()?, 11);
         }
 
         player.gaia = if player.player_type == 2 {
-            Some(GaiaData::read_from(&mut input)?)
+            Some(GaiaData::read_from(input)?)
         } else {
             None
         };
 
-        if version >= 10.55 {
+        if input.version() >= 10.55 {
             assert_eq!(input.read_u8()?, 11);
         }
 
@@ -362,7 +372,7 @@ impl Player {
             *available = input.read_u32::<LE>()? != 0;
         }
 
-        if version >= 10.55 {
+        if input.version() >= 10.55 {
             assert_eq!(input.read_u8()?, 11);
         }
 
@@ -371,25 +381,25 @@ impl Player {
             player.unit_types.push(if !available {
                 None
             } else {
-                if version >= 10.55 {
+                if input.version() >= 10.55 {
                     assert_eq!(input.read_u8()?, 22);
                 }
-                let ty = CompactUnitType::read_from(&mut input, version)?;
-                if version >= 10.55 {
+                let ty = CompactUnitType::read_from(input)?;
+                if input.version() >= 10.55 {
                     assert_eq!(input.read_u8()?, 33);
                 }
                 Some(ty)
             });
         }
 
-        if version >= 10.55 {
+        if input.version() >= 10.55 {
             assert_eq!(input.read_u8()?, 11);
         }
 
-        player.visible_map = VisibleMap::read_from(&mut input, version)?;
-        player.visible_resources = VisibleResources::read_from(&mut input)?;
+        player.visible_map = VisibleMap::read_from(input)?;
+        player.visible_resources = VisibleResources::read_from(input)?;
 
-        if version >= 10.55 {
+        if input.version() >= 10.55 {
             assert_eq!(input.read_u8()?, 11);
         }
 
@@ -397,13 +407,13 @@ impl Player {
             let _list_size = input.read_u32::<LE>()?;
             let _grow_size = input.read_u32::<LE>()?;
             let mut units = vec![];
-            while let Some(unit) = Unit::read_from(&mut input, version)? {
+            while let Some(unit) = Unit::read_from(input)? {
                 units.push(unit);
             }
             units
         };
 
-        if version >= 10.55 {
+        if input.version() >= 10.55 {
             assert_eq!(input.read_u8()?, 11);
         }
 
@@ -411,13 +421,13 @@ impl Player {
             let _list_size = input.read_u32::<LE>()?;
             let _grow_size = input.read_u32::<LE>()?;
             let mut units = vec![];
-            while let Some(unit) = Unit::read_from(&mut input, version)? {
+            while let Some(unit) = Unit::read_from(input)? {
                 units.push(unit);
             }
             units
         };
 
-        if version >= 10.55 {
+        if input.version() >= 10.55 {
             assert_eq!(input.read_u8()?, 11);
         }
 
@@ -425,22 +435,17 @@ impl Player {
             let _list_size = input.read_u32::<LE>()?;
             let _grow_size = input.read_u32::<LE>()?;
             let mut units = vec![];
-            while let Some(unit) = Unit::read_from(&mut input, version)? {
+            while let Some(unit) = Unit::read_from(input)? {
                 units.push(unit);
             }
             units
         };
 
-        if version >= 10.55 {
+        if input.version() >= 10.55 {
             assert_eq!(input.read_u8()?, 11);
         }
 
         Ok(player)
-    }
-
-    pub fn read_info(&mut self, input: impl Read, _version: f32) -> Result<()> {
-        self.victory = VictoryConditions::read_from(input, true)?;
-        Ok(())
     }
 }
 
@@ -453,14 +458,14 @@ pub struct VisibleMap {
     pub tiles: Vec<i8>,
 }
 
-impl VisibleMap {
-    pub fn read_from(mut input: impl Read, version: f32) -> Result<Self> {
+impl ReadableHeaderElement for VisibleMap {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         let mut map = VisibleMap {
             width: input.read_u32::<LE>()?,
             height: input.read_u32::<LE>()?,
             ..Default::default()
         };
-        if version >= 6.70 {
+        if input.version() >= 6.70 {
             map.explored_tiles_count = input.read_u32::<LE>()?;
         }
         map.player_id = input.read_u16::<LE>()?.try_into().unwrap();
@@ -478,8 +483,8 @@ pub struct VisibleResource {
     pub location: (u8, u8),
 }
 
-impl VisibleResource {
-    pub fn read_from(mut input: impl Read) -> Result<Self> {
+impl ReadableHeaderElement for VisibleResource {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         Ok(VisibleResource {
             object_id: input.read_u32::<LE>()?.into(),
             distance: input.read_u8()?,
@@ -494,8 +499,8 @@ pub struct VisibleResources {
     lists: Vec<Vec<VisibleResource>>,
 }
 
-impl VisibleResources {
-    pub fn read_from(mut input: impl Read) -> Result<Self> {
+impl ReadableHeaderElement for VisibleResources {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         let num_lists = input.read_u32::<LE>()?;
         let mut sizes = vec![];
         for _ in 0..num_lists {
@@ -506,7 +511,7 @@ impl VisibleResources {
         for size in sizes {
             let mut list = Vec::with_capacity(size.try_into().unwrap());
             for _ in 0..size {
-                list.push(VisibleResource::read_from(&mut input)?);
+                list.push(VisibleResource::read_from(input)?);
             }
             lists.push(list);
         }
@@ -533,15 +538,15 @@ pub struct GaiaData {
     wolf_counts: [u32; 10],
 }
 
-impl GaiaData {
-    pub fn read_from(mut input: impl Read) -> Result<Self> {
+impl ReadableHeaderElement for GaiaData {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         let mut gaia = GaiaData {
             update_time: input.read_u32::<LE>()?,
             update_nature: input.read_u32::<LE>()?,
             ..Default::default()
         };
         for creature in gaia.creatures.iter_mut() {
-            *creature = GaiaCreature::read_from(&mut input)?;
+            *creature = GaiaCreature::read_from(input)?;
         }
         gaia.next_wolf_attack_update_time = input.read_u32::<LE>()?;
         gaia.wolf_attack_update_interval = input.read_u32::<LE>()?;
@@ -557,12 +562,12 @@ impl GaiaData {
         for v in gaia.wolf_current_villagers.iter_mut() {
             *v = input.read_u32::<LE>()?;
         }
-        gaia.wolf_current_villager = read_opt_u32(&mut input)?;
+        gaia.wolf_current_villager = read_opt_u32(input)?;
         gaia.wolf_villager_count = input.read_u32::<LE>()?;
         for wolf in gaia.wolves.iter_mut() {
-            *wolf = GaiaWolfInfo::read_from(&mut input)?;
+            *wolf = GaiaWolfInfo::read_from(input)?;
         }
-        gaia.current_wolf = read_opt_u32(&mut input)?;
+        gaia.current_wolf = read_opt_u32(input)?;
         input.read_u32_into::<LE>(&mut gaia.wolf_counts[..])?;
         Ok(gaia)
     }
@@ -575,16 +580,18 @@ pub struct GaiaCreature {
     pub max: u32,
 }
 
-impl GaiaCreature {
-    pub fn read_from(mut input: impl Read) -> Result<Self> {
+impl ReadableHeaderElement for GaiaCreature {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         Ok(GaiaCreature {
             growth_rate: input.read_f32::<LE>()?,
             remainder: input.read_f32::<LE>()?,
             max: input.read_u32::<LE>()?,
         })
     }
+}
 
-    pub fn write_to(&self, mut output: impl Write) -> Result<()> {
+impl WritableHeaderElement for GaiaCreature {
+    fn write_to<W: Write>(&self, output: &mut W) -> Result<()> {
         output.write_f32::<LE>(self.growth_rate)?;
         output.write_f32::<LE>(self.remainder)?;
         output.write_u32::<LE>(self.max)?;
@@ -598,15 +605,17 @@ pub struct GaiaWolfInfo {
     pub distance: f32,
 }
 
-impl GaiaWolfInfo {
-    pub fn read_from(mut input: impl Read) -> Result<Self> {
+impl ReadableHeaderElement for GaiaWolfInfo {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         Ok(GaiaWolfInfo {
             id: input.read_u32::<LE>()?,
             distance: input.read_f32::<LE>()?,
         })
     }
+}
 
-    pub fn write_to(self, mut output: impl Write) -> Result<()> {
+impl WritableHeaderElement for GaiaWolfInfo {
+    fn write_to<W: Write>(&self, output: &mut W) -> Result<()> {
         output.write_u32::<LE>(self.id)?;
         output.write_f32::<LE>(self.distance)?;
         Ok(())
@@ -632,8 +641,8 @@ struct DiplomacyOffer {
     status: u8,
 }
 
-impl DiplomacyOffer {
-    pub fn read_from(mut input: impl Read) -> Result<Self> {
+impl ReadableHeaderElement for DiplomacyOffer {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         let mut offer = DiplomacyOffer {
             sequence: input.read_u8()?,
             started_by: input.read_u8()?,
@@ -663,15 +672,15 @@ pub struct HistoryInfo {
     pub events: Vec<HistoryEvent>,
 }
 
-impl HistoryInfo {
-    pub fn read_from(mut input: impl Read, version: f32) -> Result<Self> {
+impl ReadableHeaderElement for HistoryInfo {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         let _padding = input.read_u8()?;
         let num_entries = input.read_u32::<LE>()?;
         let _num_events = input.read_u32::<LE>()?;
         let entries_capacity = input.read_u32::<LE>()?;
         let mut entries = Vec::with_capacity(entries_capacity.try_into().unwrap());
         for _ in 0..num_entries {
-            entries.push(HistoryEntry::read_from(&mut input, version)?);
+            entries.push(HistoryEntry::read_from(input)?);
         }
 
         let _padding = input.read_u8()?;
@@ -679,7 +688,7 @@ impl HistoryInfo {
         let num_events = input.read_u32::<LE>()?;
         let mut events = Vec::with_capacity(num_events.try_into().unwrap());
         for _ in 0..num_events {
-            events.push(HistoryEvent::read_from(&mut input)?);
+            events.push(HistoryEvent::read_from(input)?);
         }
 
         let _razings = input.read_i32::<LE>()?;
@@ -727,8 +736,8 @@ pub struct HistoryEvent {
     pub params: (f32, f32, f32),
 }
 
-impl HistoryEvent {
-    pub fn read_from(mut input: impl Read) -> Result<Self> {
+impl ReadableHeaderElement for HistoryEvent {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         Ok(HistoryEvent {
             event_type: input.read_i8()?,
             time_slice: input.read_u32::<LE>()?,
@@ -748,8 +757,8 @@ pub struct HistoryEntry {
     pub military_population: u16,
 }
 
-impl HistoryEntry {
-    pub fn read_from(mut input: impl Read, _version: f32) -> Result<Self> {
+impl ReadableHeaderElement for HistoryEntry {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         let civilian_population = input.read_u16::<LE>()?;
         let military_population = input.read_u16::<LE>()?;
         Ok(HistoryEntry {
@@ -767,8 +776,8 @@ pub struct TechState {
     pub time_modifier: i16,
 }
 
-impl TechState {
-    pub fn read_from(mut input: impl Read) -> Result<Self> {
+impl ReadableHeaderElement for TechState {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         Ok(TechState {
             progress: input.read_f32::<LE>()?,
             state: input.read_i16::<LE>()?,
@@ -787,12 +796,12 @@ pub struct PlayerTech {
     pub tech_states: Vec<TechState>,
 }
 
-impl PlayerTech {
-    pub fn read_from(mut input: impl Read) -> Result<Self> {
+impl ReadableHeaderElement for PlayerTech {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         let num_techs = input.read_u16::<LE>()?;
         let mut tech_states = Vec::with_capacity(usize::from(num_techs));
         for _ in 0..num_techs {
-            tech_states.push(TechState::read_from(&mut input)?);
+            tech_states.push(TechState::read_from(input)?);
         }
         Ok(Self { tech_states })
     }
@@ -801,8 +810,8 @@ impl PlayerTech {
 #[derive(Debug, Clone)]
 pub struct UserPatchData {}
 
-impl UserPatchData {
-    pub fn read_from(mut input: impl Read) -> Result<Self> {
+impl ReadableHeaderElement for UserPatchData {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         {
             let mut bytes = vec![0; 4080];
             input.read_exact(&mut bytes)?;

--- a/crates/genie-rec/src/reader.rs
+++ b/crates/genie-rec/src/reader.rs
@@ -285,6 +285,7 @@ impl Default for RecordingState {
     }
 }
 
+#[cfg(test)]
 mod tests {
     use crate::reader::{InflatableReader, Peek};
     use std::io::{Cursor, Read};

--- a/crates/genie-rec/src/reader.rs
+++ b/crates/genie-rec/src/reader.rs
@@ -296,7 +296,9 @@ mod tests {
         let cursor = Cursor::new(data);
         let mut inflatable_buffer = InflatableReader::new_with_capacity(cursor, 4);
         let mut buffer = [0; 4];
-        inflatable_buffer.read(&mut buffer).expect("Failed to read");
+        inflatable_buffer
+            .read_exact(&mut buffer)
+            .expect("Failed to read");
         assert_eq!(&[0, 1, 2, 3], &buffer);
         assert_eq!(&[4, 5], inflatable_buffer.peek(2).expect("Failed to peek"));
         assert_eq!(
@@ -308,7 +310,9 @@ mod tests {
             inflatable_buffer.peek(6).expect("Failed to peek")
         );
         let mut buffer = [0; 8];
-        inflatable_buffer.read(&mut buffer).expect("Failed to read");
+        inflatable_buffer
+            .read_exact(&mut buffer)
+            .expect("Failed to read");
         assert_eq!(&[4, 5, 6, 7, 8, 9, 10, 11], &buffer);
     }
 }

--- a/crates/genie-rec/src/reader.rs
+++ b/crates/genie-rec/src/reader.rs
@@ -1,0 +1,286 @@
+use crate::{GameVariant, GameVersion};
+use std::cmp::min;
+use std::io;
+use std::io::{BufRead, Read};
+
+/// A struct implementing `BufRead` that uses a small, single-use, stack-allocated buffer, intended
+/// for reading only the first few bytes from a file.
+pub(crate) struct SmallBufReader<R>
+where
+    R: Read,
+{
+    buffer: [u8; 256],
+    pointer: usize,
+    reader: R,
+}
+
+impl<R> SmallBufReader<R>
+where
+    R: Read,
+{
+    pub(crate) fn new(reader: R) -> Self {
+        Self {
+            buffer: [0; 256],
+            pointer: 0,
+            reader,
+        }
+    }
+}
+
+impl<R> Read for SmallBufReader<R>
+where
+    R: Read,
+{
+    fn read(&mut self, output: &mut [u8]) -> io::Result<usize> {
+        self.reader.read(output)
+    }
+}
+
+impl<R> BufRead for SmallBufReader<R>
+where
+    R: Read,
+{
+    fn fill_buf(&mut self) -> io::Result<&[u8]> {
+        self.reader.read_exact(&mut self.buffer[self.pointer..])?;
+        Ok(&self.buffer[self.pointer..])
+    }
+
+    fn consume(&mut self, len: usize) {
+        self.pointer += len;
+    }
+}
+
+/// dynamically allocated buffered reader, by method of "inflation"
+/// The inflation allows us to "peek" into streams, without destroying data
+/// Reading from the buffer also only advances the pointer inside the buffer
+/// Only once another peek is done, data is rearranged (or simply overwritten if the whole buffer has been consumed)
+#[derive(Debug)]
+pub struct InflatableReader<R> {
+    /// inner reader
+    inner: R,
+    /// buffer for peek support, only inflates when needed
+    inflatable_buffer: Vec<u8>,
+    /// Position in our inflatable buffer
+    position_in_buffer: usize,
+}
+
+impl<R> InflatableReader<R> {
+    pub fn new(inner: R) -> Self {
+        Self::new_with_capacity(inner, 4096)
+    }
+
+    pub fn new_with_capacity(inner: R, capacity: usize) -> Self {
+        InflatableReader {
+            inner,
+            inflatable_buffer: Vec::with_capacity(capacity),
+            position_in_buffer: 0,
+        }
+    }
+}
+
+pub trait Peek {
+    fn peek(&mut self, amount: usize) -> io::Result<&[u8]>;
+}
+
+impl<R: Read> Peek for &mut InflatableReader<R> {
+    fn peek(&mut self, amount: usize) -> io::Result<&[u8]> {
+        (*self).peek(amount)
+    }
+}
+
+impl<R: Read> Peek for InflatableReader<R> {
+    /// Peek into inner reader, returns a slice owned by the [InflatableReader],
+    /// if data isn't available in the buffer yet, it will read it into the inner buffer
+    /// and inflate the buffer if needed.
+    fn peek(&mut self, amount: usize) -> io::Result<&[u8]> {
+        // cache this info, since we fuck around with position_in_buffer
+        let buffered_data_length = self.inflatable_buffer.len() - self.position_in_buffer;
+
+        // quick return because we have all the data to peek already
+        if buffered_data_length <= amount {
+            return Ok(
+                &self.inflatable_buffer[self.position_in_buffer..self.position_in_buffer + amount]
+            );
+        }
+
+        // from this point on we can assume that we need to allocate more, and [amount] is always the bigger value
+
+        // see how much we're missing
+        let missing = amount - buffered_data_length;
+
+        // we were at the end of our buffer, just reset the position without resizing yet.
+        if self.position_in_buffer == self.inflatable_buffer.len() {
+            self.position_in_buffer = 0;
+        } else {
+            // if we have enough capacity to house the missing data, just skip this part
+            if self.inflatable_buffer.capacity() >= (missing + self.inflatable_buffer.len()) {
+                let inflatable_buffer_len = self.inflatable_buffer.len();
+                // copy the data to the front, so we can allocate the least amount of data,
+                // or, skip the allocation altogether if we're lucky :)
+                self.inflatable_buffer
+                    .copy_within(self.position_in_buffer..inflatable_buffer_len, 0);
+                self.position_in_buffer = buffered_data_length;
+            }
+        }
+
+        // Check what the length would be of our new buffer, and resize if needed
+        let new_length = self.position_in_buffer + amount;
+        if new_length != self.inflatable_buffer.len() {
+            self.inflatable_buffer.resize(new_length, 0);
+        }
+
+        // read the missing data
+        let actually_read = self
+            .inner
+            .read(&mut self.inflatable_buffer[self.position_in_buffer + buffered_data_length..])?;
+        // if e.g. end of file or reading from network stream
+        if actually_read != missing {
+            // will always be shorter
+            self.inflatable_buffer
+                .truncate(self.position_in_buffer + buffered_data_length + actually_read);
+        }
+
+        Ok(&self.inflatable_buffer[self.position_in_buffer
+            ..self.position_in_buffer + buffered_data_length + actually_read])
+    }
+}
+
+impl<R: Read> Read for InflatableReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if buf.is_empty() {
+            return Ok(0);
+        }
+
+        let fulfilled: usize = if self.inflatable_buffer.len() != self.position_in_buffer {
+            let to_consume = min(
+                buf.len(),
+                self.inflatable_buffer.len() - self.position_in_buffer,
+            );
+            buf[..to_consume].copy_from_slice(
+                &self.inflatable_buffer
+                    [self.position_in_buffer..to_consume + self.position_in_buffer],
+            );
+            to_consume
+        } else {
+            0
+        };
+
+        if buf.len() - fulfilled == 0 {
+            self.position_in_buffer += fulfilled;
+            return Ok(fulfilled);
+        }
+
+        match self.inner.read(&mut buf[fulfilled..]) {
+            Ok(size) => {
+                self.position_in_buffer += fulfilled;
+                Ok(fulfilled + size)
+            }
+            err => err,
+        }
+    }
+}
+
+#[derive(Debug)]
+/// Light wrapper around a reader, which allows us to store state
+pub struct RecordingHeaderReader<R> {
+    /// Inner reader, wrapped in an inflatable reader for peeking support
+    inner: InflatableReader<R>,
+    /// Current state tracker by reader, stores version and map info
+    state: RecordingState,
+}
+
+impl<R> RecordingHeaderReader<R> {
+    pub fn new(inner: R) -> Self {
+        Self {
+            inner: InflatableReader::new(inner),
+            state: Default::default(),
+        }
+    }
+
+    pub fn version(&self) -> f32 {
+        self.state.version
+    }
+
+    pub fn game_version(&self) -> GameVersion {
+        self.state.game_version
+    }
+
+    pub fn variant(&self) -> GameVariant {
+        self.state.variant
+    }
+
+    pub fn tile_count(&self) -> usize {
+        self.state.tile_count
+    }
+
+    pub fn map_width(&self) -> u32 {
+        self.state.map_width
+    }
+
+    pub fn map_height(&self) -> u32 {
+        self.state.map_height
+    }
+
+    pub fn num_players(&self) -> u16 {
+        self.state.num_players
+    }
+
+    pub fn set_version<V: Into<GameVersion>>(&mut self, game_version: V, version: f32) {
+        let game_version = game_version.into();
+        // Should we actually throw here or smth?
+        if let Some(variant) = GameVariant::resolve_variant(&game_version, version) {
+            self.state.variant = variant;
+        }
+
+        self.state.version = version;
+        self.state.game_version = game_version;
+    }
+
+    pub fn set_map_size(&mut self, width: u32, height: u32) {
+        self.state.map_width = width;
+        self.state.map_height = height;
+        self.state.tile_count = width as usize * height as usize;
+    }
+
+    pub fn set_num_players(&mut self, num_players: u16) {
+        self.state.num_players = num_players
+    }
+}
+
+impl<R: Read> Read for RecordingHeaderReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+impl<R: Read> Peek for RecordingHeaderReader<R> {
+    fn peek(&mut self, amount: usize) -> io::Result<&[u8]> {
+        self.inner.peek(amount)
+    }
+}
+
+#[derive(Copy, Clone, Debug)]
+struct RecordingState {
+    version: f32,
+    game_version: GameVersion,
+    variant: GameVariant,
+    num_players: u16,
+    map_width: u32,
+    map_height: u32,
+    /// width * height, for ease of use
+    tile_count: usize,
+}
+
+impl Default for RecordingState {
+    fn default() -> Self {
+        RecordingState {
+            version: 0.0,
+            game_version: Default::default(),
+            variant: GameVariant::Trial,
+            num_players: 0,
+            map_width: 0,
+            map_height: 0,
+            tile_count: 0,
+        }
+    }
+}

--- a/crates/genie-rec/src/string_table.rs
+++ b/crates/genie-rec/src/string_table.rs
@@ -1,3 +1,5 @@
+use crate::element::{ReadableHeaderElement, WritableHeaderElement};
+use crate::reader::RecordingHeaderReader;
 use crate::Result;
 use byteorder::{ReadBytesExt, WriteBytesExt, LE};
 use std::io::{Read, Write};
@@ -16,7 +18,23 @@ impl StringTable {
         }
     }
 
-    pub fn read_from(mut input: impl Read) -> Result<Self> {
+    pub fn max_strings(&self) -> u16 {
+        self.max_strings
+    }
+
+    pub fn num_strings(&self) -> u16 {
+        let len = self.strings.len();
+        assert!(len < u16::max_value() as usize);
+        len as u16
+    }
+
+    pub fn strings(&self) -> &Vec<String> {
+        &self.strings
+    }
+}
+
+impl ReadableHeaderElement for StringTable {
+    fn read_from<R: Read>(input: &mut RecordingHeaderReader<R>) -> Result<Self> {
         let max_strings = input.read_u16::<LE>()?;
         let num_strings = input.read_u16::<LE>()?;
         let _ptr = input.read_u32::<LE>()?;
@@ -34,8 +52,10 @@ impl StringTable {
             strings,
         })
     }
+}
 
-    pub fn write_to<W: Write>(&self, handle: &mut W) -> Result<()> {
+impl WritableHeaderElement for StringTable {
+    fn write_to<W: Write>(&self, handle: &mut W) -> Result<()> {
         handle.write_u16::<LE>(self.max_strings)?;
         handle.write_u16::<LE>(self.num_strings())?;
         handle.write_u32::<LE>(0)?;
@@ -48,20 +68,6 @@ impl StringTable {
         }
 
         Ok(())
-    }
-
-    pub fn max_strings(&self) -> u16 {
-        self.max_strings
-    }
-
-    pub fn num_strings(&self) -> u16 {
-        let len = self.strings.len();
-        assert!(len < u16::max_value() as usize);
-        len as u16
-    }
-
-    pub fn strings(&self) -> &Vec<String> {
-        &self.strings
     }
 }
 

--- a/crates/genie-rec/src/version.rs
+++ b/crates/genie-rec/src/version.rs
@@ -1,0 +1,264 @@
+use std::cmp::Ordering;
+use std::fmt;
+use std::fmt::{Debug, Display};
+use std::io::Read;
+
+/// the variant of AoE2 game
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub enum GameVariant {
+    /// A trial version, either AoC or AoE
+    Trial,
+    /// Age of Kings
+    AgeOfKings,
+    /// Age of Conquerors
+    AgeOfConquerors,
+    /// User Patch
+    UserPatch,
+    /// Forgotten Empires mod
+    ForgottenEmpires,
+    /// AoE2:HD release
+    HighDefinition,
+    /// AoE2:DE release
+    DefinitiveEdition,
+}
+
+pub const TRIAL_VERSION: GameVersion = GameVersion(*b"TRL 9.3\0");
+pub const AGE_OF_KINGS_VERSION: GameVersion = GameVersion(*b"VER 9.3\0");
+pub const AGE_OF_CONQUERORS_VERSION: GameVersion = GameVersion(*b"VER 9.4\0");
+pub const FORGOTTEN_EMPIRES_VERSION: GameVersion = GameVersion(*b"VER 9.5\0");
+
+// So last known AoC version is 11.76
+// Since all versions only have a precision of 2
+// We can save do + 0.01
+pub const HD_SAVE_VERSION: f32 = 11.77;
+
+pub const DE_SAVE_VERSION: f32 = 12.97;
+
+use GameVariant::*;
+
+impl GameVariant {
+    pub fn resolve_variant(version: &GameVersion, sub_version: f32) -> Option<GameVariant> {
+        // taken from https://github.com/goto-bus-stop/recanalyst/blob/master/src/Analyzers/VersionAnalyzer.php
+
+        Some(match *version {
+            // Either AOC or AOK trial, just return Trial :shrug:
+            TRIAL_VERSION => Trial,
+            AGE_OF_KINGS_VERSION => AgeOfKings,
+            AGE_OF_CONQUERORS_VERSION if sub_version >= DE_SAVE_VERSION => DefinitiveEdition,
+            AGE_OF_CONQUERORS_VERSION if sub_version >= HD_SAVE_VERSION => HighDefinition,
+            AGE_OF_CONQUERORS_VERSION => AgeOfConquerors,
+            FORGOTTEN_EMPIRES_VERSION => ForgottenEmpires,
+            // UserPatch uses VER 9.<N>\0 where N is anything between 8 and F
+            GameVersion([b'V', b'E', b'R', b' ', b'9', b'.', b'8'..=b'F', b'\0']) => UserPatch,
+            _ => return None,
+        })
+    }
+
+    pub fn is_original(&self) -> bool {
+        matches!(self, Trial | AgeOfKings | AgeOfConquerors)
+    }
+
+    pub fn is_mod(&self) -> bool {
+        matches!(self, ForgottenEmpires | UserPatch)
+    }
+
+    pub fn is_update(&self) -> bool {
+        matches!(self, HighDefinition | DefinitiveEdition)
+    }
+}
+
+/// A bit of a weird comparing check
+/// It follows the hierarchy of what game is based on what
+///
+/// Thus AgeOfConquerors is bigger than AgeOfKings and HighDefinition is bigger than AgeOfConquers etc.
+///
+/// The confusing part is around HighDefinition and UserPatch
+/// UserPatch is neither bigger, smaller or equal to the -new- editions created by MSFT and vice versa
+impl PartialOrd for GameVariant {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        // quick return for equal stuff :)
+        if other == self {
+            return Some(Ordering::Equal);
+        }
+
+        // Try to not use Ord operators here, to make sure we don't fall in weird recursive traps
+        let is_mod = self.is_mod() || other.is_mod();
+        let update = self.is_update() || other.is_update();
+        let original = self.is_original() || other.is_original();
+
+        // Can't compare between user patch and hd and up
+        if is_mod && update {
+            return None;
+        }
+
+        if original && (is_mod || update) {
+            return Some(if self.is_original() {
+                Ordering::Less
+            } else {
+                Ordering::Greater
+            });
+        }
+
+        // So this part is a bit confusing
+        // but basically we removed all comparisons that are between e.g. mod, update and original
+        // and we removed all comparisons that are equal
+        // so the only comparison left is within their own class
+        Some(match self {
+            // Trial is only compared to AoK and AoC, and is the first version, thus always less
+            Trial => Ordering::Less,
+            // AoK can only be greater if compared against trial
+            AgeOfKings if other == &Trial => Ordering::Greater,
+            AgeOfKings => Ordering::Less,
+            // AoC will always be greater
+            AgeOfConquerors => Ordering::Greater,
+            // Can we compare UP and FE???
+            UserPatch | ForgottenEmpires => return None,
+            // HD can only be compared to DE, and vice versa
+            HighDefinition => Ordering::Less,
+            DefinitiveEdition => Ordering::Greater,
+        })
+    }
+}
+
+/// The game data version string. In practice, this does not really reflect the game version.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub struct GameVersion([u8; 8]);
+
+impl From<&[u8; 8]> for GameVersion {
+    fn from(val: &[u8; 8]) -> Self {
+        GameVersion(*val)
+    }
+}
+
+/// I am very lazy :)
+impl From<&[u8; 7]> for GameVersion {
+    fn from(val: &[u8; 7]) -> Self {
+        let mut whole = [0; 8];
+        whole[..7].copy_from_slice(val);
+        GameVersion(whole)
+    }
+}
+
+impl Default for GameVersion {
+    fn default() -> Self {
+        Self([0; 8])
+    }
+}
+
+impl Debug for GameVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", std::str::from_utf8(&self.0).unwrap())
+    }
+}
+
+impl Display for GameVersion {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", std::str::from_utf8(&self.0).unwrap())
+    }
+}
+
+impl GameVersion {
+    /// Read the game version string from an input stream.
+    pub fn read_from<R: Read>(input: &mut R) -> crate::Result<Self> {
+        let mut game_version = [0; 8];
+        input.read_exact(&mut game_version)?;
+        Ok(Self(game_version))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::GameVariant::*;
+    use crate::*;
+
+    #[test]
+    pub fn test_game_variant_resolution() {
+        assert_eq!(
+            Some(Trial),
+            GameVariant::resolve_variant(&TRIAL_VERSION, 0.0)
+        );
+
+        assert_eq!(
+            Some(AgeOfKings),
+            GameVariant::resolve_variant(&AGE_OF_KINGS_VERSION, 0.0)
+        );
+
+        assert_eq!(
+            Some(AgeOfConquerors),
+            GameVariant::resolve_variant(&AGE_OF_CONQUERORS_VERSION, 0.0)
+        );
+
+        assert_eq!(
+            Some(HighDefinition),
+            GameVariant::resolve_variant(&AGE_OF_CONQUERORS_VERSION, HD_SAVE_VERSION)
+        );
+
+        assert_eq!(
+            Some(DefinitiveEdition),
+            GameVariant::resolve_variant(&AGE_OF_CONQUERORS_VERSION, DE_SAVE_VERSION)
+        );
+
+        assert_eq!(
+            Some(UserPatch),
+            GameVariant::resolve_variant(&b"VER 9.A".into(), 0.0),
+        );
+
+        assert_eq!(
+            Some(ForgottenEmpires),
+            GameVariant::resolve_variant(&b"VER 9.5".into(), 0.0),
+        );
+    }
+
+    #[test]
+    pub fn test_game_variant_comparison() {
+        // Am I going add all cases here? WHO KNOWS
+        assert!(Trial < AgeOfKings);
+        assert!(AgeOfKings > Trial);
+        assert!(Trial < AgeOfConquerors);
+        assert!(AgeOfConquerors > Trial);
+        assert!(Trial < ForgottenEmpires);
+        assert!(ForgottenEmpires > Trial);
+        assert!(Trial < UserPatch);
+        assert!(UserPatch > Trial);
+        assert!(Trial < HighDefinition);
+        assert!(HighDefinition > Trial);
+        assert!(Trial < DefinitiveEdition);
+        assert!(DefinitiveEdition > Trial);
+
+        assert!(AgeOfKings < AgeOfConquerors);
+        assert!(AgeOfConquerors > AgeOfKings);
+        assert!(AgeOfKings < ForgottenEmpires);
+        assert!(ForgottenEmpires > AgeOfKings);
+        assert!(AgeOfKings < UserPatch);
+        assert!(UserPatch > AgeOfKings);
+        assert!(AgeOfKings < HighDefinition);
+        assert!(HighDefinition > AgeOfKings);
+        assert!(AgeOfKings < DefinitiveEdition);
+        assert!(DefinitiveEdition > AgeOfKings);
+
+        assert!(AgeOfConquerors < ForgottenEmpires);
+        assert!(ForgottenEmpires > AgeOfConquerors);
+        assert!(AgeOfConquerors < UserPatch);
+        assert!(UserPatch > AgeOfConquerors);
+        assert!(AgeOfConquerors < HighDefinition);
+        assert!(HighDefinition > AgeOfConquerors);
+        assert!(AgeOfConquerors < DefinitiveEdition);
+        assert!(DefinitiveEdition > AgeOfConquerors);
+
+        assert_eq!(false, ForgottenEmpires < UserPatch);
+        assert_eq!(false, UserPatch > ForgottenEmpires);
+        assert_eq!(false, ForgottenEmpires < HighDefinition);
+        assert_eq!(false, HighDefinition > ForgottenEmpires);
+        assert_eq!(false, ForgottenEmpires < DefinitiveEdition);
+        assert_eq!(false, DefinitiveEdition > ForgottenEmpires);
+
+        assert_eq!(false, UserPatch < HighDefinition);
+        assert_eq!(false, HighDefinition > UserPatch);
+        assert_eq!(false, UserPatch < DefinitiveEdition);
+        assert_eq!(false, DefinitiveEdition > UserPatch);
+
+        assert!(HighDefinition < DefinitiveEdition);
+        assert!(DefinitiveEdition > HighDefinition);
+        // yes i was
+    }
+}

--- a/crates/genie-support/src/read.rs
+++ b/crates/genie-support/src/read.rs
@@ -16,7 +16,7 @@ use std::io::{self, Error, ErrorKind, Read, Result};
 /// assert_eq!(read_opt_u16(&mut zero).unwrap(), Some(0));
 /// ```
 #[inline]
-pub fn read_opt_u16<T, R>(mut input: R) -> Result<Option<T>>
+pub fn read_opt_u16<T, R>(input: &mut R) -> Result<Option<T>>
 where
     T: TryFrom<u16>,
     T::Error: std::error::Error + Send + Sync + 'static,
@@ -46,7 +46,7 @@ where
 /// assert_eq!(read_opt_u32(&mut one).unwrap(), Some(1));
 /// ```
 #[inline]
-pub fn read_opt_u32<T, R>(mut input: R) -> Result<Option<T>>
+pub fn read_opt_u32<T, R>(input: &mut R) -> Result<Option<T>>
 where
     T: TryFrom<u32>,
     T::Error: std::error::Error + Send + Sync + 'static,


### PR DESCRIPTION
This also includes some new traits/structs that are in preparation for the DE parsing, (e.g. there's a recording version that either uses 8 vs 7 byte tiles, which requires peeking over the tile list to see which it is)

also using `input: &mut R` allows us to just pass the same reference through, instead of having a weird chain where we keep creating a new mutable reference to a our reader (which is actually  mutable reference etc.) this was also why the type recursion was going on in `UnitAction`