### PR TITLE
Use From instead of Into to convert TechTreeDependencyType to i32

### DIFF
--- a/crates/genie-dat/src/tech_tree.rs
+++ b/crates/genie-dat/src/tech_tree.rs
@@ -194,11 +194,9 @@ impl TryFrom<i32> for TechTreeDependencyType {
     }
 }
 
-// FIXME: implementation of `From` is preferred since it gives you `Into<_>`
-// for free where the reverse isn't true
-impl Into<i32> for TechTreeDependencyType {
-    fn into(self) -> i32 {
-        self as i32
+impl From<TechTreeDependencyType> for i32 {
+    fn from(tech_tree_dependency_type: TechTreeDependencyType) -> i32 {
+        tech_tree_dependency_type as i32
     }
 }
 


### PR DESCRIPTION
Implmenting From gives the Into implementation for free.
Fixes a clippy issue.